### PR TITLE
Changed circleci config to only notify on develop and master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,11 @@
 version: 2
+
+experimental:
+  notify:
+    branches:
+      only:
+        - master
+        - develop
 jobs:
   build:
     working_directory: ~/code


### PR DESCRIPTION
Tested by breaking build, didn't send notification to channel. (Afterwards, I rebased to remove the bad commit)