### PR TITLE
Update syncing to update existing entities instead of replacing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     //Time-Ago RelativeTimeTextView
     implementation 'com.github.curioustechizen.android-ago:library:1.3.4'
 
+    // Database Debugging
+    debugImplementation 'com.amitshekhar.android:debug-db:1.0.2'
+
     implementation 'com.facebook.fresco:fresco:1.7.1'
     implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'

--- a/app/schemas/org.fundacionparaguaya.advisorapp.data.local.LocalDatabase/1.json
+++ b/app/schemas/org.fundacionparaguaya.advisorapp.data.local.LocalDatabase/1.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "9a5f35775f7454e1f629426ff867b05c",
+    "identityHash": "b58f655081c24442660243035a1f4a37",
     "entities": [
       {
         "tableName": "families",
@@ -143,14 +143,6 @@
               "remote_id"
             ],
             "createSql": "CREATE UNIQUE INDEX `index_families_remote_id` ON `${TABLE_NAME}` (`remote_id`)"
-          },
-          {
-            "name": "index_families_code",
-            "unique": true,
-            "columnNames": [
-              "code"
-            ],
-            "createSql": "CREATE UNIQUE INDEX `index_families_code` ON `${TABLE_NAME}` (`code`)"
           }
         ],
         "foreignKeys": []
@@ -313,7 +305,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"9a5f35775f7454e1f629426ff867b05c\")"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"b58f655081c24442660243035a1f4a37\")"
     ]
   }
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/local/FamilyDao.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/local/FamilyDao.java
@@ -12,7 +12,7 @@ import org.fundacionparaguaya.advisorapp.models.Family;
 
 import java.util.List;
 
-import static android.arch.persistence.room.OnConflictStrategy.REPLACE;
+import static android.arch.persistence.room.OnConflictStrategy.FAIL;
 
 /**
  * The access utility for retrieving families from the local database.
@@ -37,13 +37,13 @@ public interface FamilyDao {
      * @return The pending families.
      */
     @Query("SELECT * FROM families WHERE remote_id IS NULL")
-    List<Family> queryPendingFamilies();
+    List<Family> queryPendingFamiliesNow();
 
-    @Insert(onConflict = REPLACE)
+    @Query("SELECT * FROM families WHERE remote_id = :remoteId")
+    Family queryRemoteFamilyNow(long remoteId);
+
+    @Insert(onConflict = FAIL)
     long insertFamily(Family family);
-
-    @Insert(onConflict = REPLACE)
-    long[] insertFamilies(Family ... families);
 
     @Update
     int updateFamily(Family family);

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/local/SnapshotDao.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/local/SnapshotDao.java
@@ -11,7 +11,7 @@ import org.fundacionparaguaya.advisorapp.models.Snapshot;
 
 import java.util.List;
 
-import static android.arch.persistence.room.OnConflictStrategy.REPLACE;
+import static android.arch.persistence.room.OnConflictStrategy.FAIL;
 
 /**
  * The access utility for retrieving snapshots from the local database.
@@ -42,11 +42,12 @@ public interface SnapshotDao {
     @Query("SELECT * FROM snapshots WHERE remote_id IS NULL")
     List<Snapshot> queryPendingSnapshots();
 
-    @Insert(onConflict = REPLACE)
-    long insertSnapshot(Snapshot snapshot);
 
-    @Insert(onConflict = REPLACE)
-    void insertSnapshots(Snapshot ... snapshots);
+    @Query("SELECT * FROM snapshots WHERE remote_id = :remoteId")
+    Snapshot queryRemoteSnapshotNow(long remoteId);
+
+    @Insert(onConflict = FAIL)
+    long insertSnapshot(Snapshot snapshot);
 
     @Update
     int updateSnapshot(Snapshot snapshot);

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/local/SurveyDao.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/local/SurveyDao.java
@@ -5,12 +5,13 @@ import android.arch.lifecycle.LiveData;
 import android.arch.persistence.room.Dao;
 import android.arch.persistence.room.Insert;
 import android.arch.persistence.room.Query;
+import android.arch.persistence.room.Update;
 
 import org.fundacionparaguaya.advisorapp.models.Survey;
 
 import java.util.List;
 
-import static android.arch.persistence.room.OnConflictStrategy.REPLACE;
+import static android.arch.persistence.room.OnConflictStrategy.FAIL;
 
 /**
  * The access utility for retrieving surveys from the local database.
@@ -29,9 +30,12 @@ public interface SurveyDao {
     @Query("SELECT * FROM surveys WHERE id = :id")
     Survey querySurveyNow(int id);
 
-    @Insert(onConflict = REPLACE)
+    @Query("SELECT * FROM surveys WHERE remote_id = :remoteId")
+    Survey queryRemoteSurveyNow(long remoteId);
+
+    @Insert(onConflict = FAIL)
     long insertSurvey(Survey survey);
 
-    @Insert(onConflict = REPLACE)
-    void insertSurveys(Survey... surveys);
+    @Update
+    int updateSurvey(Survey survey);
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/models/Family.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/models/Family.java
@@ -3,7 +3,6 @@ package org.fundacionparaguaya.advisorapp.models;
 import android.arch.persistence.room.ColumnInfo;
 import android.arch.persistence.room.Embedded;
 import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.Ignore;
 import android.arch.persistence.room.Index;
 import android.arch.persistence.room.PrimaryKey;
 import android.support.annotation.NonNull;
@@ -13,7 +12,7 @@ import android.support.annotation.NonNull;
  */
 
 @Entity(tableName = "families",
-        indices={@Index(value="remote_id", unique=true), @Index(value="code", unique=true)})
+        indices={@Index(value="remote_id", unique=true)})
 public class Family {
     @PrimaryKey(autoGenerate = true)
     private int id;

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/models/Survey.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/models/Survey.java
@@ -61,6 +61,10 @@ public class Survey {
         return id;
     }
 
+    public void setId(int id) {
+        this.id = id;
+    }
+
     public Long getRemoteId() {
         return remoteId;
     }


### PR DESCRIPTION
Closes #73 and closes #76
Families no longer blink when the page is refreshed, and when in a family page the page doesn't crash.
Also, snapshots are able to be recorded! You just need to make sure every field is filled with the correct type (integer fields should have a parsable number in them, text fields should not be blank, and each indicator question is answered), and the date of birth question has a date of the format 1980-12-10 in it.