### PR TITLE
Hotfix: Normalize background question font

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/adapters/SurveyQuestionAdapter.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/adapters/SurveyQuestionAdapter.java
@@ -268,7 +268,7 @@ public class SurveyQuestionAdapter extends RecyclerView.Adapter {
             if(question.getOptions() != null){
 
                 mSpinnerAdapter =
-                        new SurveyQuestionSpinnerAdapter(itemView.getContext(), R.layout.item_tv_spinner);
+                        new SurveyQuestionSpinnerAdapter(itemView.getContext(), R.layout.item_tv_questionspinner);
 
                 mSpinnerAdapter.setValues(question.getOptions().keySet().toArray(
                         new String[question.getOptions().size()]));

--- a/app/src/main/res/layout/item_questiondropdown.xml
+++ b/app/src/main/res/layout/item_questiondropdown.xml
@@ -26,9 +26,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:id="@+id/tv_questionall_title"
-                    android:textAppearance="@style/Heading.Large"
-                    tools:text="What is your family's monthly income?"
-                    android:textSize="48sp"/>
+                    android:textAppearance="@style/Heading"
+                    tools:text="What is your family's monthly income?"/>
 
             <RelativeLayout
                     android:layout_width="wrap_content"
@@ -46,9 +45,9 @@
                         android:layout_width="wrap_content"
                         android:layout_alignParentStart="true"
                         android:minWidth="140dp"
-                        android:layout_height="40dp"
-                        android:paddingEnd="20dp"
+                        android:layout_height="wrap_content"
                         android:paddingStart="0dp"
+                        android:textAppearance="@style/Heading"
                         android:background="@drawable/spinner_background"
                         android:id="@+id/spinner_questiondropdown"/>
             </RelativeLayout>

--- a/app/src/main/res/layout/item_questiontext.xml
+++ b/app/src/main/res/layout/item_questiontext.xml
@@ -24,9 +24,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:id="@+id/tv_questionall_title"
-                android:textAppearance="@style/Heading.Large"
-                tools:text="What is your family's monthly income?"
-                android:textSize="48sp"/>
+                android:textAppearance="@style/Heading"
+                tools:text="What is your family's monthly income?"/>
 
 
         <android.support.v7.widget.AppCompatEditText android:layout_width="wrap_content"
@@ -34,11 +33,10 @@
                   android:layout_marginTop="20dp"
                   android:id="@+id/et_questiontext_answer"
                   android:minWidth="250dp"
-                  android:textAppearance="@style/Heading"
+                  android:textAppearance="@style/Body.Large"
                   android:textCursorDrawable="@drawable/dark_cursor"
                   android:backgroundTint="@color/black"
-                  android:hint="Your Response"
-                  android:textSize="40sp"/>
+                  android:hint="@string/your_response"/>
         <View
                 android:layout_width="match_parent"
                 android:layout_height="0dp"

--- a/app/src/main/res/layout/item_tv_questionspinner.xml
+++ b/app/src/main/res/layout/item_tv_questionspinner.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView
+        xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/textViewSpinnerItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="8dp"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp"
+        android:paddingEnd="12dp"
+        android:layout_gravity="center_vertical"
+        android:textAppearance="@style/Body.Large"
+        tools:text="Test Item"
+/>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -93,6 +93,12 @@
     <style name="CardHeading.Yellow">
         <item name="android:textColor">@color/survey_lightyellow</item>
     </style>
+    
+    <style name="Body.Large" parent="@android:style/TextAppearance">
+        <item name="android:fontFamily">@font/opensans_regular</item>
+        <item name="android:textColor">@color/black</item>
+        <item name="android:textSize">24sp</item>
+    </style>
 
     <style name="Body" parent="@android:style/TextAppearance">
         <item name="android:fontFamily">@font/opensans_regular</item>


### PR DESCRIPTION
Changes the font size of the background questions to help them fit on the screen in all screen sizes, along with removing the text when no option is selected (because it was not translatable).
![image](https://user-images.githubusercontent.com/1918630/36129438-3499eaea-1035-11e8-8265-835d1beff9d5.png)

Also updates the layout of the all families cards to remove unneeded whitespace
![image](https://user-images.githubusercontent.com/1918630/36129446-403d7740-1035-11e8-8124-c13f73312488.png)
