### PR TITLE
Add a created date to snapshots to avoid crash

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/models/Snapshot.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/models/Snapshot.java
@@ -76,7 +76,7 @@ public class Snapshot implements Comparable<Snapshot>{
     @Ignore
     public Snapshot(Family family, Survey survey) {
         this(0, null, family == null ? null : family.getId(), survey.getId(),
-                new HashMap<>(), new HashMap<>(), new HashMap<>(), new LinkedList<>(), null);
+                new HashMap<>(), new HashMap<>(), new HashMap<>(), new LinkedList<>(), new Date());
         if (family != null) {
             fillPersonalResponses(family, survey);
         }


### PR DESCRIPTION
The indicator list on the family detail page will crash if there is a snapshot without a date in it; this fixes that issue.