### PR TITLE
Added versioning from git

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ android {
         targetSdkVersion 27
         multiDexEnabled true
         versionCode 11
-        versionName "v1.2.2 (Roadrunner)"
+        versionName versioning.info.full
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
         renderscriptTargetApi 27

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,15 @@ buildscript {
     }
 }
 
+plugins {
+    id 'net.nemerosa.versioning' version '2.0.0'
+}
+
+versioning {
+    releaseMode = 'snapshot'
+    displayMode = 'snapshot'
+}
+
 allprojects {
     repositories {
         jcenter()


### PR DESCRIPTION
Added automatic versioning based off of git. https://github.com/nemerosa/versioning

This is the branching model we will follow: 

![image](https://user-images.githubusercontent.com/19956321/36645127-4e4f22f0-1a32-11e8-9282-337a22737f27.png)

For release 1.3, for example, we will create a branch named release/1.3. If there is no tag matching 1.3.0, then the version will be 1.3.0. If there is, then it'll increment by 1 (so be 1.3.1). Essentially, we will create a release branch for each release and make patches on that same branch. Until we make a tag, the version will have the word "SNAPSHOT" in it to indicate that it isn't the final product. 

Our releases (besides for testing) should never be a SNAPSHOT. 


