### PR TITLE
Can't write to mixpanel if the fragment no longer has context.

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/fragments/LoginFragment.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/fragments/LoginFragment.java
@@ -317,7 +317,12 @@ class LoginTask extends AsyncTask<User, Void, AuthenticationManager.Authenticati
                 mLoginFragment.mEmailView.setEnabled(true);
                 mLoginFragment.mPasswordView.setEnabled(true);
 
-                MixpanelHelper.LoginEvent.unauthenticatedFail(mLoginFragment.getContext());
+                Context c =  mLoginFragment.getActivity();
+
+                if(c !=null)
+                {
+                    MixpanelHelper.LoginEvent.unauthenticatedFail(c);
+                }
 
                 break;
                 // TODO: Tie into the connectivity watcher to determine whether the app is online


### PR DESCRIPTION
Patch for this crash.

I think that this is a symptom of something else (not clear why the fragment would have lost context unless it was in the middle of a crash) but at least this will give us a better idea of what the crash actually is.

A longer term solution would be injecting a Mixpanel client that only needs to instantiate the mixpanel object once. 