### PR TITLE
Removed warning that was crashing app in release mode

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/activities/LoginActivity.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/activities/LoginActivity.java
@@ -4,10 +4,8 @@ import android.os.Bundle;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
-
 import android.view.MotionEvent;
 import com.instabug.library.InstabugTrackingDelegate;
-import org.fundacionparaguaya.advisorapp.BuildConfig;
 import org.fundacionparaguaya.advisorapp.R;
 import org.fundacionparaguaya.advisorapp.fragments.LoginFragment;
 import org.fundacionparaguaya.advisorapp.util.Utilities;
@@ -39,12 +37,8 @@ public class LoginActivity extends AppCompatActivity {
         transaction.replace(R.id.login_root, loginFragment, LOGIN_FRAG_TAG);
         transaction.commit();
 
-        //exit the app if play services is not available. this will force them to use the latest version
-        //and avoid them finding out in the middle of a survey.
-        if(Utilities.isGooglePlayServicesAvailable(this) && !BuildConfig.DEBUG)
-        {
-            this.finish();
-        }
+        //will show dialog prompting for update if not available
+        Utilities.isGooglePlayServicesAvailable(this);
     }
 }
 


### PR DESCRIPTION
Missing logical complement operator and activity was finishing before dialog was shown.