### PR TITLE
Preload Images

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/AdvisorApplication.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/AdvisorApplication.java
@@ -1,8 +1,12 @@
 package org.fundacionparaguaya.advisorapp;
 
+import android.os.Environment;
 import android.support.multidex.MultiDexApplication;
 import com.evernote.android.job.JobManager;
+import com.facebook.cache.disk.DiskCacheConfig;
+import com.facebook.common.util.ByteConstants;
 import com.facebook.drawee.backends.pipeline.Fresco;
+import com.facebook.imagepipeline.core.ImagePipelineConfig;
 import com.instabug.library.Instabug;
 import com.instabug.library.invocation.InstabugInvocationEvent;
 import com.novoda.merlin.Merlin;
@@ -15,12 +19,16 @@ import org.fundacionparaguaya.advisorapp.jobs.JobCreator;
 import org.fundacionparaguaya.advisorapp.util.MixpanelHelper;
 
 import javax.inject.Inject;
+import java.io.File;
 
 /**
  * The advisor application.
  */
 
 public class AdvisorApplication extends MultiDexApplication {
+
+    private static final long INDICATOR_CACHE_SIZE = 500 * ByteConstants.MB;
+
     private ApplicationComponent applicationComponent;
     @Inject
     Merlin mMerlin;
@@ -30,6 +38,19 @@ public class AdvisorApplication extends MultiDexApplication {
     @Override
     public void onCreate() {
         super.onCreate();
+
+        DiskCacheConfig indicatorCacheConfig = DiskCacheConfig
+                .newBuilder(this)
+                .setMaxCacheSize(INDICATOR_CACHE_SIZE)
+                .build();
+
+        ImagePipelineConfig config = ImagePipelineConfig
+                .newBuilder(this)
+                .setSmallImageDiskCacheConfig(indicatorCacheConfig)
+                .build();
+
+        Fresco
+                .initialize(this, config);
 
         applicationComponent = DaggerApplicationComponent
                 .builder()
@@ -48,8 +69,6 @@ public class AdvisorApplication extends MultiDexApplication {
         MixpanelHelper.identify(getApplicationContext());
 
         JobManager.create(this).addJobCreator(new JobCreator(this));
-
-        Fresco.initialize(this);
     }
 
     public ApplicationComponent getApplicationComponent() {

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/dependencyinjection/ApplicationComponent.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/dependencyinjection/ApplicationComponent.java
@@ -45,8 +45,6 @@ public interface ApplicationComponent {
 
     void inject(JobCreator jobCreator);
 
-    void inject(ImageRepository imageRepository);
-
     void inject(LifeMapFragment lifeMapFragment);
 
     void inject(PriorityListFrag lifeMapFragment);

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/dependencyinjection/ApplicationComponent.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/dependencyinjection/ApplicationComponent.java
@@ -2,12 +2,14 @@ package org.fundacionparaguaya.advisorapp.dependencyinjection;
 
 import android.app.Application;
 
+import android.content.Context;
 import org.fundacionparaguaya.advisorapp.AdvisorApplication;
 import org.fundacionparaguaya.advisorapp.activities.DashActivity;
 import org.fundacionparaguaya.advisorapp.activities.EditPriorityActivity;
 import org.fundacionparaguaya.advisorapp.activities.SurveyActivity;
 import org.fundacionparaguaya.advisorapp.fragments.*;
 import org.fundacionparaguaya.advisorapp.jobs.JobCreator;
+import org.fundacionparaguaya.advisorapp.repositories.ImageRepository;
 import org.fundacionparaguaya.advisorapp.viewcomponents.ResumeSnapshotPopupWindow;
 
 import javax.inject.Singleton;
@@ -42,6 +44,8 @@ public interface ApplicationComponent {
     void inject(SurveySummaryIndicatorsFragment surveySummaryIndicatorsFragment);
 
     void inject(JobCreator jobCreator);
+
+    void inject(ImageRepository imageRepository);
 
     void inject(LifeMapFragment lifeMapFragment);
 

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/dependencyinjection/ApplicationModule.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/dependencyinjection/ApplicationModule.java
@@ -1,15 +1,14 @@
 package org.fundacionparaguaya.advisorapp.dependencyinjection;
 
 import android.app.Application;
-import android.content.Context;
 import android.content.SharedPreferences;
-
+import com.facebook.drawee.backends.pipeline.Fresco;
+import com.facebook.imagepipeline.core.ImagePipeline;
+import dagger.Module;
+import dagger.Provides;
 import org.fundacionparaguaya.advisorapp.AdvisorApplication;
 
 import javax.inject.Singleton;
-
-import dagger.Module;
-import dagger.Provides;
 
 import static android.content.Context.MODE_PRIVATE;
 

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/dependencyinjection/ApplicationModule.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/dependencyinjection/ApplicationModule.java
@@ -1,6 +1,7 @@
 package org.fundacionparaguaya.advisorapp.dependencyinjection;
 
 import android.app.Application;
+import android.content.Context;
 import android.content.SharedPreferences;
 
 import org.fundacionparaguaya.advisorapp.AdvisorApplication;

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/dependencyinjection/DatabaseModule.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/dependencyinjection/DatabaseModule.java
@@ -22,6 +22,7 @@ import org.fundacionparaguaya.advisorapp.data.remote.ServerManager;
 import org.fundacionparaguaya.advisorapp.data.remote.SnapshotService;
 import org.fundacionparaguaya.advisorapp.data.remote.SurveyService;
 import org.fundacionparaguaya.advisorapp.repositories.FamilyRepository;
+import org.fundacionparaguaya.advisorapp.repositories.ImageRepository;
 import org.fundacionparaguaya.advisorapp.repositories.SnapshotRepository;
 import org.fundacionparaguaya.advisorapp.repositories.SurveyRepository;
 import org.fundacionparaguaya.advisorapp.viewmodels.InjectionViewModelFactory;
@@ -154,6 +155,12 @@ public class DatabaseModule {
     @Singleton
     SurveyRepository provideSurveyRepository(SurveyDao surveyDao, SurveyService surveyService) {
         return new SurveyRepository(surveyDao, surveyService);
+    }
+
+    @Provides
+    @Singleton
+    ImageRepository provideImageRepository(FamilyRepository familyRepository, SurveyRepository surveyRepository) {
+        return new ImageRepository(familyRepository, surveyRepository);
     }
 
     @Provides

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/jobs/JobCreator.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/jobs/JobCreator.java
@@ -2,11 +2,8 @@ package org.fundacionparaguaya.advisorapp.jobs;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-
 import com.evernote.android.job.Job;
-
 import org.fundacionparaguaya.advisorapp.AdvisorApplication;
-import org.fundacionparaguaya.advisorapp.repositories.SurveyRepository;
 import org.fundacionparaguaya.advisorapp.repositories.SyncManager;
 
 import javax.inject.Inject;

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/jobs/JobCreator.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/jobs/JobCreator.java
@@ -6,6 +6,7 @@ import android.support.annotation.Nullable;
 import com.evernote.android.job.Job;
 
 import org.fundacionparaguaya.advisorapp.AdvisorApplication;
+import org.fundacionparaguaya.advisorapp.repositories.SurveyRepository;
 import org.fundacionparaguaya.advisorapp.repositories.SyncManager;
 
 import javax.inject.Inject;

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/ImageRepository.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/ImageRepository.java
@@ -1,0 +1,86 @@
+package org.fundacionparaguaya.advisorapp.repositories;
+
+import android.content.Context;
+import android.net.Uri;
+import android.util.Log;
+import com.facebook.common.executors.CallerThreadExecutor;
+import com.facebook.datasource.DataSource;
+import com.facebook.datasource.DataSources;
+import com.facebook.datasource.DataSubscriber;
+import com.facebook.drawee.backends.pipeline.Fresco;
+import com.facebook.imagepipeline.request.ImageRequest;
+import com.facebook.imagepipeline.request.ImageRequestBuilder;
+import org.fundacionparaguaya.advisorapp.models.*;
+
+import javax.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.String.format;
+
+/**
+ * The utility for the storage of snapshots.
+ */
+
+public class ImageRepository {
+    private static final String TAG = "ImageRepository";
+
+    private static final String NO_IMAGE= "NONE";
+
+    private final FamilyRepository mFamilyRepository;
+    private final SurveyRepository mSurveyRepository;
+
+    @Inject
+    public ImageRepository(FamilyRepository familyRepository,
+                           SurveyRepository surveyRepository) {
+        this.mFamilyRepository = familyRepository;
+        this.mSurveyRepository = surveyRepository;
+    }
+
+    /**
+     * Synchronizes the local snapshots with the remote database.
+     * @return Whether the sync was successful.
+     */
+    boolean sync() {
+
+        boolean result = true;
+
+        for(Survey survey: mSurveyRepository.getSurveysNow())
+        {
+            for(IndicatorQuestion indicatorQuestion: survey.getIndicatorQuestions())
+            {
+                for(IndicatorOption option: indicatorQuestion.getOptions())
+                {
+                    Uri imageUri = Uri.parse(option.getImageUrl());
+
+                    if(!option.getImageUrl().equals(NO_IMAGE) && !Fresco.getImagePipeline().isInDiskCacheSync(imageUri)) {
+                        ImageRequest imageRequest = ImageRequestBuilder
+                                .newBuilderWithSource(Uri.parse(option.getImageUrl()))
+                                .setCacheChoice(ImageRequest.CacheChoice.SMALL) // cache choice = small just allows us
+                                .build();                                       //to isolate survey pictures in their own cache
+
+                        Log.d(TAG, "Downloading Picture: " + option.getImageUrl());
+
+                        DataSource<Void> prefetchDataSource = Fresco.getImagePipeline().prefetchToDiskCache(imageRequest, CallerThreadExecutor.getInstance());
+
+                        try {
+                            DataSources.waitForFinalResult(prefetchDataSource);
+                        } catch (Throwable throwable) {
+                            result = false; //error downloading
+                        }
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Clears all image caches
+     */
+    void clean() {
+        Fresco.getImagePipeline().clearCaches();
+    }
+}

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/ImageRepository.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/ImageRepository.java
@@ -1,23 +1,19 @@
 package org.fundacionparaguaya.advisorapp.repositories;
 
-import android.content.Context;
 import android.net.Uri;
 import android.util.Log;
 import com.facebook.common.executors.CallerThreadExecutor;
 import com.facebook.datasource.DataSource;
 import com.facebook.datasource.DataSources;
-import com.facebook.datasource.DataSubscriber;
 import com.facebook.drawee.backends.pipeline.Fresco;
+import com.facebook.imagepipeline.core.ImagePipeline;
 import com.facebook.imagepipeline.request.ImageRequest;
 import com.facebook.imagepipeline.request.ImageRequestBuilder;
-import org.fundacionparaguaya.advisorapp.models.*;
+import org.fundacionparaguaya.advisorapp.models.IndicatorOption;
+import org.fundacionparaguaya.advisorapp.models.IndicatorQuestion;
+import org.fundacionparaguaya.advisorapp.models.Survey;
 
 import javax.inject.Inject;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static java.lang.String.format;
 
 /**
  * The utility for the storage of snapshots.
@@ -46,31 +42,40 @@ public class ImageRepository {
 
         boolean result = true;
 
+        //todo: add timeout once it is added to fresco https://github.com/facebook/fresco/pull/2068
         for(Survey survey: mSurveyRepository.getSurveysNow())
         {
             for(IndicatorQuestion indicatorQuestion: survey.getIndicatorQuestions())
             {
                 for(IndicatorOption option: indicatorQuestion.getOptions())
                 {
-                    Uri imageUri = Uri.parse(option.getImageUrl());
-
-                    if(!option.getImageUrl().equals(NO_IMAGE) && !Fresco.getImagePipeline().isInDiskCacheSync(imageUri)) {
-                        ImageRequest imageRequest = ImageRequestBuilder
-                                .newBuilderWithSource(Uri.parse(option.getImageUrl()))
-                                .setCacheChoice(ImageRequest.CacheChoice.SMALL) // cache choice = small just allows us
-                                .build();                                       //to isolate survey pictures in their own cache
-
-                        Log.d(TAG, "Downloading Picture: " + option.getImageUrl());
-
-                        DataSource<Void> prefetchDataSource = Fresco.getImagePipeline().prefetchToDiskCache(imageRequest, CallerThreadExecutor.getInstance());
-
-                        try {
-                            DataSources.waitForFinalResult(prefetchDataSource);
-                        } catch (Throwable throwable) {
-                            result = false; //error downloading
-                        }
-                    }
+                    result &= downloadImage(Uri.parse(option.getImageUrl()));
                 }
+            }
+        }
+
+        return result;
+    }
+
+    private boolean downloadImage(Uri imageUri)
+    {
+        boolean result = true;
+
+        if(!imageUri.toString().contains(NO_IMAGE) && !Fresco.getImagePipeline().isInDiskCacheSync(imageUri)) {
+            ImageRequest imageRequest = ImageRequestBuilder
+                    .newBuilderWithSource(imageUri)
+                    .setCacheChoice(ImageRequest.CacheChoice.SMALL) // cache choice = small just allows us
+                    .build();                                       //to isolate survey pictures in their own cache
+
+            DataSource<Void> prefetchDataSource = Fresco.getImagePipeline().prefetchToDiskCache(imageRequest, CallerThreadExecutor.getInstance());
+
+            try {
+                DataSources.waitForFinalResult(prefetchDataSource);
+
+                if(prefetchDataSource.isFinished()) Log.d(TAG, "Downloaded Picture: " + imageUri.toString());
+            } catch (Throwable throwable) {
+                result = false; //error downloading
+                Log.d(TAG, "Downloaded Failed: " + imageUri.toString());
             }
         }
 

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/SurveyRepository.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/SurveyRepository.java
@@ -3,21 +3,18 @@ package org.fundacionparaguaya.advisorapp.repositories;
 import android.arch.lifecycle.LiveData;
 import android.support.annotation.Nullable;
 import android.util.Log;
-
 import org.fundacionparaguaya.advisorapp.data.local.SurveyDao;
 import org.fundacionparaguaya.advisorapp.data.remote.SurveyService;
 import org.fundacionparaguaya.advisorapp.data.remote.intermediaterepresentation.IrMapper;
 import org.fundacionparaguaya.advisorapp.data.remote.intermediaterepresentation.SurveyIr;
 import org.fundacionparaguaya.advisorapp.models.Survey;
+import retrofit2.Response;
 
+import javax.inject.Inject;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
-
-import javax.inject.Inject;
-
-import retrofit2.Response;
 
 import static java.lang.String.format;
 

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/SyncManager.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/SyncManager.java
@@ -146,6 +146,7 @@ public class SyncManager {
         mFamilyRepository.clean();
         mSurveyRepository.clean();
         mSnapshotRepository.clean();
+        mImageRepository.clean();
         updateProgress(NEVER, -1);
         Log.d(TAG, "clean: Finished the database clean");
     }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/viewcomponents/IndicatorCard.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/viewcomponents/IndicatorCard.java
@@ -177,7 +177,7 @@ public class IndicatorCard extends LinearLayout{
 
     public void clearImageFromMemory()
     {
-        Fresco.getImagePipeline().evictFromCache(mImageUri);
+        Fresco.getImagePipeline().evictFromMemoryCache(mImageUri);
     }
 
     //performClick is added, the fact that the function is still highlighted is a bug in Android Studio

--- a/app/src/test/java/org/fundacionparaguaya/advisorapp/models/ModelUtils.java
+++ b/app/src/test/java/org/fundacionparaguaya/advisorapp/models/ModelUtils.java
@@ -49,6 +49,16 @@ public class ModelUtils {
                 .build();
     }
 
+    public static List<Survey> surveyList()
+    {
+        ArrayList<Survey> surveys = new ArrayList<>();
+        surveys.add(survey());
+        surveys.add(survey());
+        surveys.add(survey());
+
+        return surveys;
+    }
+
     public static Survey survey() {
         List<BackgroundQuestion> personalQuestions = new ArrayList<>();
         personalQuestions.add(new BackgroundQuestion("firstName",

--- a/app/src/test/java/org/fundacionparaguaya/advisorapp/repositories/ImageRepositoryTest.java
+++ b/app/src/test/java/org/fundacionparaguaya/advisorapp/repositories/ImageRepositoryTest.java
@@ -1,0 +1,109 @@
+package org.fundacionparaguaya.advisorapp.repositories;
+
+import android.content.Context;
+import android.net.Uri;
+import android.test.suitebuilder.annotation.SmallTest;
+import com.facebook.datasource.DataSource;
+import com.facebook.datasource.DataSources;
+import com.facebook.drawee.backends.pipeline.Fresco;
+import com.facebook.imagepipeline.core.ImagePipeline;
+import com.facebook.imagepipeline.request.ImageRequest;
+import org.fundacionparaguaya.advisorapp.models.Survey;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.fundacionparaguaya.advisorapp.models.ModelUtils.survey;
+import static org.fundacionparaguaya.advisorapp.models.ModelUtils.surveyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for the <code>ImageRepository</code>.
+ */
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({DataSources.class, Fresco.class, Uri.class})
+@SmallTest
+public class ImageRepositoryTest {
+
+    @Mock
+    ImagePipeline imagePipeline;
+
+    @Mock
+    DataSource<Void> mPrefetchImageSource;
+
+    @Mock
+    SurveyRepository mSurveyRepository;
+
+    @Mock
+    FamilyRepository mFamilyRepository;
+
+    @Mock
+    Uri uri;
+
+    /**
+     * Verifies that images not currently in the cache are downloaded when the image repository is synced.
+     * @throws Throwable
+     */
+    @Test
+    public void ShouldSyncSurveyPhotos() throws Throwable {
+        setUp();
+        when(imagePipeline.isInDiskCacheSync(any(Uri.class))).thenReturn(false);
+
+        List<Survey> surveys = surveyList();
+
+        when(mSurveyRepository.getSurveysNow()).thenReturn(surveys);
+
+        imageRepository().sync();
+
+        int numOfPictures = 0;
+
+        for(Survey s: surveys) {
+            numOfPictures += s.getIndicatorQuestions().size() * 3;
+        }
+
+        verify(imagePipeline, times(numOfPictures)).prefetchToDiskCache(any(ImageRequest.class), any());
+    }
+
+    /**
+     * Verifies that images in the disk cache are not redownloaded
+     */
+    @Test
+    public void ShouldNotResyncSurveyPhotos() throws Throwable {
+
+        setUp();
+
+        when(imagePipeline.isInDiskCacheSync(any(Uri.class))).thenReturn(true);
+
+        List<Survey> surveys = surveyList();
+
+        when(mSurveyRepository.getSurveysNow()).thenReturn(surveys);
+        imageRepository().sync();
+        verify(imagePipeline, never()).prefetchToDiskCache(any(), any());
+    }
+
+    private void setUp() throws Throwable {
+        PowerMockito.mockStatic(DataSources.class);
+        PowerMockito.mockStatic(Fresco.class);
+        PowerMockito.mockStatic(Uri.class);
+
+        when((Uri.parse(anyString()))).thenReturn(uri);
+        when(DataSources.waitForFinalResult(mPrefetchImageSource)).thenReturn(null);
+        when(Fresco.getImagePipeline()).thenReturn(imagePipeline);
+
+        when(imagePipeline.prefetchToDiskCache(any(ImageRequest.class), any())).thenReturn(mPrefetchImageSource);
+    }
+
+    public ImageRepository imageRepository()
+    {
+        return new ImageRepository(mFamilyRepository, mSurveyRepository);
+    }
+}

--- a/app/src/test/java/org/fundacionparaguaya/advisorapp/repositories/SyncManagerTest.java
+++ b/app/src/test/java/org/fundacionparaguaya/advisorapp/repositories/SyncManagerTest.java
@@ -56,6 +56,9 @@ public class SyncManagerTest {
     ConnectivityWatcher connectivityWatcher;
     @Mock
     Observer observer;
+    @Mock
+    ImageRepository mImageRepository;
+
     private MutableLiveData<Boolean> isOnline;
 
     @Rule
@@ -78,6 +81,7 @@ public class SyncManagerTest {
         verify(familyRepository, times(1)).sync(any());
         verify(surveyRepository, times(1)).sync(any());
         verify(snapshotRepository, times(1)).sync(any());
+        verify(mImageRepository, times(1)).sync();
     }
 
     @Test
@@ -90,6 +94,7 @@ public class SyncManagerTest {
         verify(familyRepository, times(1)).sync(any());
         verify(surveyRepository, times(1)).sync(any());
         verify(snapshotRepository, times(1)).sync(any());
+        verify(mImageRepository, times(1)).sync();
     }
 
     @Test
@@ -97,6 +102,7 @@ public class SyncManagerTest {
         when(familyRepository.sync(any())).thenReturn(true);
         when(surveyRepository.sync(any())).thenReturn(true);
         when(snapshotRepository.sync(any())).thenReturn(true);
+        when(mImageRepository.sync()).thenReturn(true);
 
         SyncManager syncManager = syncManager();
         assertThat(syncManager.sync(), is(true));
@@ -107,6 +113,7 @@ public class SyncManagerTest {
         when(familyRepository.sync(any())).thenReturn(false);
         when(surveyRepository.sync(any())).thenReturn(true);
         when(snapshotRepository.sync(any())).thenReturn(true);
+        when(mImageRepository.sync()).thenReturn(true);
 
         SyncManager syncManager = syncManager();
         assertThat(syncManager.sync(), is(false));
@@ -117,6 +124,7 @@ public class SyncManagerTest {
         when(familyRepository.sync(any())).thenReturn(true);
         when(surveyRepository.sync(any())).thenThrow(new RuntimeException());
         when(snapshotRepository.sync(any())).thenReturn(true);
+        when(mImageRepository.sync()).thenReturn(true);
 
         SyncManager syncManager = syncManager();
         assertThat(syncManager.sync(), is(false));
@@ -127,6 +135,7 @@ public class SyncManagerTest {
         when(familyRepository.sync(any())).thenReturn(true);
         when(surveyRepository.sync(any())).thenReturn(true);
         when(snapshotRepository.sync(any())).thenReturn(true);
+        when(mImageRepository.sync()).thenReturn(true);
 
         SyncManager syncManager = syncManager();
         syncManager.sync();
@@ -139,6 +148,7 @@ public class SyncManagerTest {
         when(familyRepository.sync(any())).thenReturn(true);
         when(surveyRepository.sync(any())).thenReturn(false);
         when(snapshotRepository.sync(any())).thenReturn(true);
+        when(mImageRepository.sync()).thenReturn(true);
 
         SyncManager syncManager = syncManager();
         syncManager.sync();
@@ -244,6 +254,7 @@ public class SyncManagerTest {
         when(familyRepository.sync(any())).thenReturn(true);
         when(surveyRepository.sync(any())).thenReturn(true);
         when(snapshotRepository.sync(any())).thenReturn(true);
+        when(mImageRepository.sync()).thenReturn(true);
 
         SyncManager syncManager = syncManager();
         long lastSyncedTime = syncManager.getProgress().getValue().getLastSyncedTime();
@@ -263,6 +274,7 @@ public class SyncManagerTest {
         when(familyRepository.sync(any())).thenReturn(true);
         when(surveyRepository.sync(any())).thenReturn(true);
         when(snapshotRepository.sync(any())).thenReturn(false);
+        when(mImageRepository.sync()).thenReturn(true);
 
         SyncManager syncManager = syncManager();
         syncManager.sync();
@@ -294,6 +306,7 @@ public class SyncManagerTest {
         verify(familyRepository).clean();
         verify(surveyRepository).clean();
         verify(snapshotRepository).clean();
+        verify(mImageRepository).clean();
     }
 
     @Test
@@ -306,6 +319,7 @@ public class SyncManagerTest {
         verify(familyRepository).clean();
         verify(surveyRepository).clean();
         verify(snapshotRepository).clean();
+        verify(mImageRepository).clean();
     }
 
     @Test
@@ -339,7 +353,7 @@ public class SyncManagerTest {
     }
 
     private SyncManager syncManager() {
-        return new SyncManager(familyRepository, surveyRepository, snapshotRepository,
+        return new SyncManager(familyRepository, surveyRepository, snapshotRepository, mImageRepository,
                 sharedPreferences, connectivityWatcher);
     }
 }


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Description <!-- [OPTIONAL] -->
<!-- Include a short description of this pull request -->
Preloads (or in Fresco terms, prefetches) survey images to the disk cache.

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Added an ImageRepository class that handles syncing images
- Added a test for ImageRepository

# Issues <!-- [IF APPLICABLE] -->
<!-- Fill in a bulleted list with issues that have been introduced or fixed -->
- Fixes
  - #396

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [ ] Logged in to the application
  - [ ] Fill out a snapshot for a new family
  - [ ] Fill out a snapshot for an existing family
  - [ ] Fill out priorities for a snapshot
  - [ ] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [ ] API Level 22
  - [ ] API Level 25
- Screen Size:
  - [ ] 7" screen size
  - [ ] 8" screen size
  - [ ] 10" screen size

To test, I deleted the app in order to make sure the cache was empty. Then, I performed a sync and made sure that all of the images were downloaded before the sync animation stopped. I immediately turned off internet to make sure the images were cached (all 50). I also performed another sync to make sure that images in the cache weren't redownloaded.
