### PR TITLE
Recolored under construction cone to match primary color

### DIFF
--- a/app/src/main/res/layout/fragment_under_construction.xml
+++ b/app/src/main/res/layout/fragment_under_construction.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v7.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical">
+                                              android:layout_width="match_parent"
+                                              android:layout_height="match_parent"
+                                              xmlns:tools="http://schemas.android.com/tools"
+                                              xmlns:app="http://schemas.android.com/apk/res-auto"
+                                              android:orientation="vertical">
     <android.support.v7.widget.AppCompatTextView android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:layout_marginTop="16dp"
@@ -19,6 +20,7 @@
            android:layout_height="match_parent"
            android:layout_marginStart="40dp"
            android:layout_marginEnd="40dp"
+           app:tint="@color/colorPrimary"
            android:src="@drawable/ic_all_construction"/>
 
     <android.support.v7.widget.AppCompatTextView android:layout_width="wrap_content"


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Description <!-- [OPTIONAL] -->
<!-- Include a short description of this pull request -->
It's self explanatory.

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- I made the cone a better color

# Screenshots <!-- [IF APPLICABLE] -->
<!-- If this change involves any visible changes, include screenshots of key screens here -->
Do I have to? Pls no. 
![image](https://user-images.githubusercontent.com/19956321/37747247-a948410c-2d54-11e8-90a7-e694523b75d5.png)


# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [ ] Logged in to the application
  - [ ] Fill out a snapshot for a new family
  - [ ] Fill out a snapshot for an existing family
  - [ ] Fill out priorities for a snapshot
  - [ ] View a family and it's priorities
- API Level:
  - [X] API Level 19
  - [ ] API Level 22
  - [X] API Level 25
- Screen Size:
  - [X] 7" screen size
  - [ ] 8" screen size
  - [ ] 10" screen size
