### PR TITLE
WIP Feature: More efficient syncing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,6 @@
 /build
 /captures
 .externalNativeBuild
-*.json
-*.json
-app/schemas/org.fundacionparaguaya.advisorapp.data.local.LocalDatabase/1.json
 app/release
 *.orig
 /gradle.properties

--- a/app/schemas/org.fundacionparaguaya.advisorapp.data.local.LocalDatabase/2.json
+++ b/app/schemas/org.fundacionparaguaya.advisorapp.data.local.LocalDatabase/2.json
@@ -1,0 +1,335 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "6e767003b97662bce53cdd3f60745e55",
+    "entities": [
+      {
+        "tableName": "families",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remote_id` INTEGER, `name` TEXT, `code` TEXT, `address` TEXT, `is_active` INTEGER NOT NULL, `longitude` REAL, `latitude` REAL, `city_id` INTEGER, `city_name` TEXT, `country_id` INTEGER, `country_name` TEXT, `family_member_first_name` TEXT, `family_member_last_name` TEXT, `family_member_birthdate` TEXT, `family_member_phone_number` TEXT, `family_member_identification_type` TEXT, `family_member_identification_number` TEXT, `family_member_gender` TEXT, `family_member_country_of_birth` TEXT, `family_member_profile_url` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location.longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.city.id",
+            "columnName": "city_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.city.name",
+            "columnName": "city_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.country.id",
+            "columnName": "country_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.country.name",
+            "columnName": "country_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.firstName",
+            "columnName": "family_member_first_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.lastName",
+            "columnName": "family_member_last_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.birthdate",
+            "columnName": "family_member_birthdate",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.phoneNumber",
+            "columnName": "family_member_phone_number",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.identificationType",
+            "columnName": "family_member_identification_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.identificationNumber",
+            "columnName": "family_member_identification_number",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.gender",
+            "columnName": "family_member_gender",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.countryOfBirth",
+            "columnName": "family_member_country_of_birth",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.profileUrl",
+            "columnName": "family_member_profile_url",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_families_remote_id",
+            "unique": true,
+            "columnNames": [
+              "remote_id"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_families_remote_id` ON `${TABLE_NAME}` (`remote_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "surveys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remote_id` INTEGER, `title` TEXT, `description` TEXT, `personal_questions` TEXT, `economic_questions` TEXT, `indicator_questions` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "personalQuestions",
+            "columnName": "personal_questions",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "economicQuestions",
+            "columnName": "economic_questions",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "indicatorQuestions",
+            "columnName": "indicator_questions",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_surveys_remote_id",
+            "unique": true,
+            "columnNames": [
+              "remote_id"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_surveys_remote_id` ON `${TABLE_NAME}` (`remote_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remote_id` INTEGER, `family_id` INTEGER, `survey_id` INTEGER NOT NULL, `personal_responses` TEXT, `economic_responses` TEXT, `indicator_responses` TEXT, `priorities` TEXT, `created_at` INTEGER, FOREIGN KEY(`family_id`) REFERENCES `families`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`survey_id`) REFERENCES `surveys`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "familyId",
+            "columnName": "family_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "surveyId",
+            "columnName": "survey_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personalResponses",
+            "columnName": "personal_responses",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "economicResponses",
+            "columnName": "economic_responses",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "indicatorResponses",
+            "columnName": "indicator_responses",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priorities",
+            "columnName": "priorities",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_snapshots_family_id",
+            "unique": false,
+            "columnNames": [
+              "family_id"
+            ],
+            "createSql": "CREATE  INDEX `index_snapshots_family_id` ON `${TABLE_NAME}` (`family_id`)"
+          },
+          {
+            "name": "index_snapshots_survey_id",
+            "unique": false,
+            "columnNames": [
+              "survey_id"
+            ],
+            "createSql": "CREATE  INDEX `index_snapshots_survey_id` ON `${TABLE_NAME}` (`survey_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "families",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "family_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "surveys",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "survey_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"6e767003b97662bce53cdd3f60745e55\")"
+    ]
+  }
+}

--- a/app/schemas/org.fundacionparaguaya.advisorapp.data.local.LocalDatabase/3.json
+++ b/app/schemas/org.fundacionparaguaya.advisorapp.data.local.LocalDatabase/3.json
@@ -1,0 +1,341 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "f9e0703ea35e39e4f8e37cd69acca6a0",
+    "entities": [
+      {
+        "tableName": "families",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remote_id` INTEGER, `name` TEXT, `code` TEXT, `address` TEXT, `is_active` INTEGER NOT NULL, `longitude` REAL, `latitude` REAL, `city_id` INTEGER, `city_name` TEXT, `country_id` INTEGER, `country_name` TEXT, `family_member_first_name` TEXT, `family_member_last_name` TEXT, `family_member_birthdate` TEXT, `family_member_phone_number` TEXT, `family_member_identification_type` TEXT, `family_member_identification_number` TEXT, `family_member_gender` TEXT, `family_member_country_of_birth` TEXT, `family_member_profile_url` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location.longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.city.id",
+            "columnName": "city_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.city.name",
+            "columnName": "city_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.country.id",
+            "columnName": "country_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.country.name",
+            "columnName": "country_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.firstName",
+            "columnName": "family_member_first_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.lastName",
+            "columnName": "family_member_last_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.birthdate",
+            "columnName": "family_member_birthdate",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.phoneNumber",
+            "columnName": "family_member_phone_number",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.identificationType",
+            "columnName": "family_member_identification_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.identificationNumber",
+            "columnName": "family_member_identification_number",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.gender",
+            "columnName": "family_member_gender",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.countryOfBirth",
+            "columnName": "family_member_country_of_birth",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.profileUrl",
+            "columnName": "family_member_profile_url",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_families_remote_id",
+            "unique": true,
+            "columnNames": [
+              "remote_id"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_families_remote_id` ON `${TABLE_NAME}` (`remote_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "surveys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remote_id` INTEGER, `title` TEXT, `description` TEXT, `personal_questions` TEXT, `economic_questions` TEXT, `indicator_questions` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "personalQuestions",
+            "columnName": "personal_questions",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "economicQuestions",
+            "columnName": "economic_questions",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "indicatorQuestions",
+            "columnName": "indicator_questions",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_surveys_remote_id",
+            "unique": true,
+            "columnNames": [
+              "remote_id"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_surveys_remote_id` ON `${TABLE_NAME}` (`remote_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remote_id` INTEGER, `family_id` INTEGER, `survey_id` INTEGER NOT NULL, `in_progress` INTEGER NOT NULL, `personal_responses` TEXT, `economic_responses` TEXT, `indicator_responses` TEXT, `priorities` TEXT, `created_at` INTEGER, FOREIGN KEY(`family_id`) REFERENCES `families`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`survey_id`) REFERENCES `surveys`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "familyId",
+            "columnName": "family_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "surveyId",
+            "columnName": "survey_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inProgress",
+            "columnName": "in_progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personalResponses",
+            "columnName": "personal_responses",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "economicResponses",
+            "columnName": "economic_responses",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "indicatorResponses",
+            "columnName": "indicator_responses",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priorities",
+            "columnName": "priorities",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_snapshots_family_id",
+            "unique": false,
+            "columnNames": [
+              "family_id"
+            ],
+            "createSql": "CREATE  INDEX `index_snapshots_family_id` ON `${TABLE_NAME}` (`family_id`)"
+          },
+          {
+            "name": "index_snapshots_survey_id",
+            "unique": false,
+            "columnNames": [
+              "survey_id"
+            ],
+            "createSql": "CREATE  INDEX `index_snapshots_survey_id` ON `${TABLE_NAME}` (`survey_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "families",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "family_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "surveys",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "survey_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"f9e0703ea35e39e4f8e37cd69acca6a0\")"
+    ]
+  }
+}

--- a/app/schemas/org.fundacionparaguaya.advisorapp.data.local.LocalDatabase/4.json
+++ b/app/schemas/org.fundacionparaguaya.advisorapp.data.local.LocalDatabase/4.json
@@ -1,0 +1,347 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "4a1f5f91e70f5651289657e1db781972",
+    "entities": [
+      {
+        "tableName": "families",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remote_id` INTEGER, `name` TEXT, `code` TEXT, `address` TEXT, `is_active` INTEGER NOT NULL, `last_modified` INTEGER, `longitude` REAL, `latitude` REAL, `city_id` INTEGER, `city_name` TEXT, `country_id` INTEGER, `country_name` TEXT, `family_member_first_name` TEXT, `family_member_last_name` TEXT, `family_member_birthdate` TEXT, `family_member_phone_number` TEXT, `family_member_identification_type` TEXT, `family_member_identification_number` TEXT, `family_member_gender` TEXT, `family_member_country_of_birth` TEXT, `family_member_profile_url` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "last_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.city.id",
+            "columnName": "city_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.city.name",
+            "columnName": "city_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.country.id",
+            "columnName": "country_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.country.name",
+            "columnName": "country_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.firstName",
+            "columnName": "family_member_first_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.lastName",
+            "columnName": "family_member_last_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.birthdate",
+            "columnName": "family_member_birthdate",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.phoneNumber",
+            "columnName": "family_member_phone_number",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.identificationType",
+            "columnName": "family_member_identification_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.identificationNumber",
+            "columnName": "family_member_identification_number",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.gender",
+            "columnName": "family_member_gender",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.countryOfBirth",
+            "columnName": "family_member_country_of_birth",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.profileUrl",
+            "columnName": "family_member_profile_url",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_families_remote_id",
+            "unique": true,
+            "columnNames": [
+              "remote_id"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_families_remote_id` ON `${TABLE_NAME}` (`remote_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "surveys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remote_id` INTEGER, `title` TEXT, `description` TEXT, `personal_questions` TEXT, `economic_questions` TEXT, `indicator_questions` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "personalQuestions",
+            "columnName": "personal_questions",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "economicQuestions",
+            "columnName": "economic_questions",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "indicatorQuestions",
+            "columnName": "indicator_questions",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_surveys_remote_id",
+            "unique": true,
+            "columnNames": [
+              "remote_id"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_surveys_remote_id` ON `${TABLE_NAME}` (`remote_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remote_id` INTEGER, `family_id` INTEGER, `survey_id` INTEGER NOT NULL, `in_progress` INTEGER NOT NULL, `personal_responses` TEXT, `economic_responses` TEXT, `indicator_responses` TEXT, `priorities` TEXT, `created_at` INTEGER, FOREIGN KEY(`family_id`) REFERENCES `families`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`survey_id`) REFERENCES `surveys`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "familyId",
+            "columnName": "family_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "surveyId",
+            "columnName": "survey_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inProgress",
+            "columnName": "in_progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personalResponses",
+            "columnName": "personal_responses",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "economicResponses",
+            "columnName": "economic_responses",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "indicatorResponses",
+            "columnName": "indicator_responses",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priorities",
+            "columnName": "priorities",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_snapshots_family_id",
+            "unique": false,
+            "columnNames": [
+              "family_id"
+            ],
+            "createSql": "CREATE  INDEX `index_snapshots_family_id` ON `${TABLE_NAME}` (`family_id`)"
+          },
+          {
+            "name": "index_snapshots_survey_id",
+            "unique": false,
+            "columnNames": [
+              "survey_id"
+            ],
+            "createSql": "CREATE  INDEX `index_snapshots_survey_id` ON `${TABLE_NAME}` (`survey_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "families",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "family_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "surveys",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "survey_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"4a1f5f91e70f5651289657e1db781972\")"
+    ]
+  }
+}

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/local/FamilyDao.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/local/FamilyDao.java
@@ -30,6 +30,9 @@ public interface FamilyDao {
     @Query("SELECT * FROM families WHERE id = :id")
     Family queryFamilyNow(int id);
 
+    @Query("SELECT * FROM families WHERE last_modified >= :time")
+    List<Family> queryFamiliesModifiedSinceDateNow(long time);
+
     /**
      * Queries for all families that only exist locally, which haven't been pushed to the
      * remote database and do not have a remote ID.

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/local/LocalDatabase.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/local/LocalDatabase.java
@@ -13,7 +13,7 @@ import org.fundacionparaguaya.advisorapp.models.Survey;
 /**
  * The database storing a local cache of data for the user.
  */
-@Database(entities = {Family.class, Survey.class, Snapshot.class}, version = 3)
+@Database(entities = {Family.class, Survey.class, Snapshot.class}, version = 4)
 public abstract class LocalDatabase extends RoomDatabase {
 
     private static final Migration MIGRATION_2_3 = new Migration(2, 3) {
@@ -24,8 +24,17 @@ public abstract class LocalDatabase extends RoomDatabase {
         }
     };
 
+    private static final Migration MIGRATION_3_4 = new Migration(3, 4) {
+        @Override
+        public void migrate(@NonNull SupportSQLiteDatabase database) {
+            database.execSQL("ALTER TABLE families "
+                    + " ADD COLUMN last_modified INTEGER NOT NULL DEFAULT 0");
+        }
+    };
+
     public static final Migration[] MIGRATIONS = new Migration[] {
-            MIGRATION_2_3
+            MIGRATION_2_3,
+            MIGRATION_3_4
     };
 
     public abstract FamilyDao familyDao();

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/FamilyService.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/FamilyService.java
@@ -9,6 +9,7 @@ import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
+import retrofit2.http.Query;
 
 /**
  * The service used to retrieve families from the remote database.
@@ -18,6 +19,9 @@ public interface FamilyService {
 
     @GET("families")
     Call<List<FamilyIr>> getFamilies();
+
+    @GET("families")
+    Call<List<FamilyIr>> getFamiliesModifiedSince(@Query("last_modified_gt") String lastModified);
 
     @POST("families")
     Call<FamilyIr> postFamily(@Body FamilyIr family);

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/SurveyService.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/SurveyService.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import retrofit2.Call;
 import retrofit2.http.GET;
+import retrofit2.http.Query;
 
 /**
  * The service used to retrieve surveys from the remote database.
@@ -15,4 +16,7 @@ public interface SurveyService {
 
     @GET("surveys")
     Call<List<SurveyIr>> getSurveys();
+
+    @GET("surveys")
+    Call<List<SurveyIr>> getSurveysModifiedSince(@Query("last_modified_gt") String lastModified);
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/models/Family.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/models/Family.java
@@ -5,10 +5,14 @@ import android.arch.persistence.room.Embedded;
 import android.arch.persistence.room.Entity;
 import android.arch.persistence.room.Index;
 import android.arch.persistence.room.PrimaryKey;
+import android.arch.persistence.room.TypeConverters;
 import android.support.annotation.NonNull;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.fundacionparaguaya.advisorapp.data.local.Converters;
+
+import java.util.Date;
 
 /**
  * A family is the entity that is being helped by the advisor.
@@ -16,6 +20,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @Entity(tableName = "families",
         indices={@Index(value="remote_id", unique=true)})
+@TypeConverters(Converters.class)
 public class Family {
     @PrimaryKey(autoGenerate = true)
     private int id;
@@ -29,6 +34,8 @@ public class Family {
     private String address;
     @ColumnInfo(name="is_active")
     private boolean isActive;
+    @ColumnInfo(name="last_modified")
+    private Date lastModified;
     @Embedded
     private Location location;
     @Embedded(prefix = "family_member_")
@@ -44,7 +51,8 @@ public class Family {
                   String address,
                   Location location,
                   FamilyMember member,
-                  boolean isActive) {
+                  boolean isActive,
+                  Date lastModified) {
         this.id = id;
         this.remoteId = remoteId;
         this.name = name;
@@ -53,6 +61,7 @@ public class Family {
         this.location = location;
         this.member = member;
         this.isActive = isActive;
+        this.lastModified = lastModified;
     }
 
     public int getId() {
@@ -101,6 +110,12 @@ public class Family {
         return location;
     }
 
+    public void setLastModified(Date lastModified) {
+        this.lastModified = lastModified;
+    }
+
+    public Date getLastModified() { return lastModified; }
+
     public boolean isActive() {
         return isActive;
     }
@@ -122,6 +137,7 @@ public class Family {
                 .append(name, that.name)
                 .append(code, that.code)
                 .append(address, that.address)
+                .append(lastModified, that.lastModified)
                 .append(isActive, that.isActive)
                 .append(location, that.location)
                 .append(member, that.member)
@@ -136,6 +152,7 @@ public class Family {
                 .append(name)
                 .append(code)
                 .append(address)
+                .append(lastModified)
                 .append(isActive)
                 .append(location)
                 .append(member)
@@ -213,7 +230,7 @@ public class Family {
         }
 
         public Family build() {
-            return new Family(id, remoteId, name, code, address, location, member, isActive);
+            return new Family(id, remoteId, name, code, address, location, member, isActive, new Date());
         }
     }
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/models/Family.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/models/Family.java
@@ -168,6 +168,7 @@ public class Family {
         private Location location;
         private FamilyMember member;
         private boolean isActive = true;
+        private Date lastModified;
 
         /**
          * Sets the ID of the new family. Should only be used if overwriting an existing family!
@@ -212,6 +213,11 @@ public class Family {
             return this;
         }
 
+        public Builder lastModified(Date lastModified) {
+            this.lastModified = lastModified;
+            return this;
+        }
+
         /**
          * Fills in the information about a family that is available from a snapshot's personal
          * responses.
@@ -226,11 +232,12 @@ public class Family {
                     + member.getLastName().toUpperCase().charAt(0)
                     + "."
                     + member.getBirthdate().replace("-", ""));
+            lastModified(snapshot.getCreatedAt());
             return this;
         }
 
         public Family build() {
-            return new Family(id, remoteId, name, code, address, location, member, isActive, new Date());
+            return new Family(id, remoteId, name, code, address, location, member, isActive, lastModified);
         }
     }
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/SnapshotRepository.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/SnapshotRepository.java
@@ -17,6 +17,7 @@ import org.fundacionparaguaya.advisorapp.models.Snapshot;
 import org.fundacionparaguaya.advisorapp.models.Survey;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -176,9 +177,9 @@ public class SnapshotRepository {
         return success;
     }
 
-    private boolean pullSnapshots() {
+    private boolean pullSnapshots(Date lastSync) {
         boolean success = true;
-        for (Family family : familyRepository.getFamiliesNow()) {
+        for (Family family : familyRepository.getFamiliesModifiedSinceDateNow(lastSync)) {
             for (Survey survey : surveyRepository.getSurveysNow()) {
                 success &= pullSnapshots(family, survey);
             }
@@ -228,11 +229,11 @@ public class SnapshotRepository {
      * Synchronizes the local snapshots with the remote database.
      * @return Whether the sync was successful.
      */
-    boolean sync() {
+    boolean sync(Date lastSync) {
         boolean successful;
         successful = pushSnapshots();
         if (successful) {
-            successful = pullSnapshots();
+            successful = pullSnapshots(lastSync);
         }
 
         return successful;

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/SnapshotRepository.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/SnapshotRepository.java
@@ -177,9 +177,16 @@ public class SnapshotRepository {
         return success;
     }
 
-    private boolean pullSnapshots(Date lastSync) {
+    private boolean pullSnapshots(@Nullable Date lastSync) {
         boolean success = true;
-        for (Family family : familyRepository.getFamiliesModifiedSinceDateNow(lastSync)) {
+        List<Family> families; // the families to sync snapshots for
+        if (lastSync != null) {
+            families = familyRepository.getFamiliesModifiedSinceDateNow(lastSync);
+        } else {
+            families = familyRepository.getFamiliesNow();
+        }
+
+        for (Family family : families) {
             for (Survey survey : surveyRepository.getSurveysNow()) {
                 success &= pullSnapshots(family, survey);
             }
@@ -229,7 +236,7 @@ public class SnapshotRepository {
      * Synchronizes the local snapshots with the remote database.
      * @return Whether the sync was successful.
      */
-    boolean sync(Date lastSync) {
+    boolean sync(@Nullable Date lastSync) {
         boolean successful;
         successful = pushSnapshots();
         if (successful) {

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/SurveyRepository.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/SurveyRepository.java
@@ -10,6 +10,8 @@ import org.fundacionparaguaya.advisorapp.data.remote.intermediaterepresentation.
 import org.fundacionparaguaya.advisorapp.models.Survey;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -65,10 +67,11 @@ public class SurveyRepository {
         }
     }
 
-    private boolean pullSurveys() {
+    private boolean pullSurveys(Date lastSync) {
         try {
+            String lastSyncString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm").format(lastSync);
             Response<List<SurveyIr>> response =
-                    surveyService.getSurveys().execute();
+                    surveyService.getSurveysModifiedSince(lastSyncString).execute();
 
             if (!response.isSuccessful() || response.body() == null) {
                 Log.w(TAG, format("pullSurveys: Could not pull surveys! %s", response.errorBody().string()));
@@ -95,8 +98,8 @@ public class SurveyRepository {
      * Synchronizes the local surveys with the remote database.
      * @return Whether the sync was successful.
      */
-    boolean sync() {
-        return pullSurveys();
+    boolean sync(Date lastSync) {
+        return pullSurveys(lastSync);
     }
 
     void clean() {

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/SurveyRepository.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/SurveyRepository.java
@@ -1,6 +1,7 @@
 package org.fundacionparaguaya.advisorapp.repositories;
 
 import android.arch.lifecycle.LiveData;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import org.fundacionparaguaya.advisorapp.data.local.SurveyDao;
@@ -67,11 +68,16 @@ public class SurveyRepository {
         }
     }
 
-    private boolean pullSurveys(Date lastSync) {
+    private boolean pullSurveys(@Nullable Date lastSync) {
         try {
-            String lastSyncString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm").format(lastSync);
-            Response<List<SurveyIr>> response =
-                    surveyService.getSurveysModifiedSince(lastSyncString).execute();
+            Response<List<SurveyIr>> response;
+            if (lastSync != null) {
+                String lastSyncString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm")
+                        .format(lastSync);
+                response = surveyService.getSurveysModifiedSince(lastSyncString).execute();
+            } else {
+                response = surveyService.getSurveys().execute();
+            }
 
             if (!response.isSuccessful() || response.body() == null) {
                 Log.w(TAG, format("pullSurveys: Could not pull surveys! %s", response.errorBody().string()));
@@ -98,7 +104,7 @@ public class SurveyRepository {
      * Synchronizes the local surveys with the remote database.
      * @return Whether the sync was successful.
      */
-    boolean sync(Date lastSync) {
+    boolean sync(@Nullable Date lastSync) {
         return pullSurveys(lastSync);
     }
 

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/SyncManager.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/SyncManager.java
@@ -3,6 +3,7 @@ package org.fundacionparaguaya.advisorapp.repositories;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
 import android.content.SharedPreferences;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import org.fundacionparaguaya.advisorapp.data.remote.ConnectivityWatcher;
@@ -83,12 +84,12 @@ public class SyncManager {
         updateProgress(SYNCING);
         boolean result = true;
 
-        Date lastSync;
+        @Nullable Date lastSync;
         SyncProgress progress = mProgress.getValue();
-        if (progress != null && progress.getLastSyncedTime() != 0) {
+        if (progress != null && progress.getLastSyncedTime() != -1) {
             lastSync = new Date(progress.getLastSyncedTime() - LAST_SYNC_ERROR_MARGIN);
         } else {
-            lastSync = new Date(0L);
+            lastSync = null;
         }
 
         try {

--- a/app/src/test/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/IrMapperTest.java
+++ b/app/src/test/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/IrMapperTest.java
@@ -42,7 +42,10 @@ public class IrMapperTest {
         Family family = IrMapper.mapFamily(ir);
         family.setId(1);
 
-        assertThat(family, is(family(member())));
+        Family expected = family(member());
+        expected.setLastModified(null);
+
+        assertThat(family, is(expected));
     }
 
     @Test

--- a/app/src/test/java/org/fundacionparaguaya/advisorapp/models/FamilyTest.java
+++ b/app/src/test/java/org/fundacionparaguaya/advisorapp/models/FamilyTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import static org.fundacionparaguaya.advisorapp.models.ModelUtils.family;
 import static org.fundacionparaguaya.advisorapp.models.ModelUtils.member;
 import static org.fundacionparaguaya.advisorapp.models.ModelUtils.personalResponses;
+import static org.fundacionparaguaya.advisorapp.models.ModelUtils.time;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,6 +28,7 @@ public class FamilyTest {
     public void builder_ShouldFillFamily_snapshot() {
         Snapshot snapshot = mock(Snapshot.class);
         when(snapshot.getPersonalResponses()).thenReturn(personalResponses());
+        when(snapshot.getCreatedAt()).thenReturn(time());
 
         Family family = Family.builder()
                 .snapshot(snapshot)
@@ -36,7 +38,6 @@ public class FamilyTest {
         assertThat(family.getRemoteId(), is(nullValue()));
         family.setId(1);
         family.setRemoteId(1L);
-        family.setLastModified(family(null).getLastModified());
 
         assertThat(family, is(family(member())));
     }

--- a/app/src/test/java/org/fundacionparaguaya/advisorapp/models/FamilyTest.java
+++ b/app/src/test/java/org/fundacionparaguaya/advisorapp/models/FamilyTest.java
@@ -36,6 +36,8 @@ public class FamilyTest {
         assertThat(family.getRemoteId(), is(nullValue()));
         family.setId(1);
         family.setRemoteId(1L);
+        family.setLastModified(family(null).getLastModified());
+
         assertThat(family, is(family(member())));
     }
 }

--- a/app/src/test/java/org/fundacionparaguaya/advisorapp/models/ModelUtils.java
+++ b/app/src/test/java/org/fundacionparaguaya/advisorapp/models/ModelUtils.java
@@ -32,6 +32,7 @@ public class ModelUtils {
                 .isActive(true)
                 .code("US.GW.20100427")
                 .member(member)
+                .lastModified(time())
                 .build();
     }
 
@@ -91,7 +92,7 @@ public class ModelUtils {
 
         return new Snapshot(1, 1L, family.getId(), survey.getId(), false,
                 personalResponses, economicResponses, indicatorResponses, priorities,
-                time("2018-02-07T00:51:08"));
+                time());
     }
 
     public static Map<BackgroundQuestion, String> personalResponses() {
@@ -109,6 +110,10 @@ public class ModelUtils {
 
     private static BackgroundQuestion bq(String name) {
         return new BackgroundQuestion(name, "", true, STRING, PERSONAL);
+    }
+
+    public static Date time() {
+        return time("2018-02-07T00:51:08");
     }
 
     public static Date time(String time) {

--- a/app/src/test/java/org/fundacionparaguaya/advisorapp/repositories/SyncManagerTest.java
+++ b/app/src/test/java/org/fundacionparaguaya/advisorapp/repositories/SyncManagerTest.java
@@ -75,9 +75,9 @@ public class SyncManagerTest {
         SyncManager syncManager = syncManager();
         syncManager.sync();
 
-        verify(familyRepository, times(1)).sync(date());
-        verify(surveyRepository, times(1)).sync(date());
-        verify(snapshotRepository, times(1)).sync(date());
+        verify(familyRepository, times(1)).sync(any());
+        verify(surveyRepository, times(1)).sync(any());
+        verify(snapshotRepository, times(1)).sync(any());
     }
 
     @Test
@@ -87,9 +87,9 @@ public class SyncManagerTest {
         SyncManager syncManager = syncManager();
         syncManager.sync();
 
-        verify(familyRepository, times(1)).sync(date());
-        verify(surveyRepository, times(1)).sync(date());
-        verify(snapshotRepository, times(1)).sync(date());
+        verify(familyRepository, times(1)).sync(any());
+        verify(surveyRepository, times(1)).sync(any());
+        verify(snapshotRepository, times(1)).sync(any());
     }
 
     @Test
@@ -161,8 +161,7 @@ public class SyncManagerTest {
     @Test
     public void sync_ShouldUseLastSyncTime() {
         long lastSyncedTime = 10000L;
-        when(sharedPreferences.getLong(eq(SyncManager.KEY_LAST_SYNC_TIME), anyLong()))
-                .thenReturn(lastSyncedTime);
+        setLastSynced(lastSyncedTime);
         when(familyRepository.sync(any())).thenReturn(true);
         when(surveyRepository.sync(any())).thenReturn(true);
         when(snapshotRepository.sync(any())).thenReturn(false);
@@ -178,9 +177,7 @@ public class SyncManagerTest {
 
     @Test
     public void sync_ShouldUseLastSyncTime_first() {
-        long lastSyncedTime = 0L;
-        when(sharedPreferences.getLong(eq(SyncManager.KEY_LAST_SYNC_TIME), anyLong()))
-                .thenReturn(lastSyncedTime);
+        setNeverSynced();
         when(familyRepository.sync(any())).thenReturn(true);
         when(surveyRepository.sync(any())).thenReturn(true);
         when(snapshotRepository.sync(any())).thenReturn(false);
@@ -188,10 +185,9 @@ public class SyncManagerTest {
         SyncManager syncManager = syncManager();
         syncManager.sync();
 
-        Date date = new Date(lastSyncedTime);
-        verify(familyRepository, times(1)).sync(date);
-        verify(surveyRepository, times(1)).sync(date);
-        verify(snapshotRepository, times(1)).sync(date);
+        verify(familyRepository, times(1)).sync(null);
+        verify(surveyRepository, times(1)).sync(null);
+        verify(snapshotRepository, times(1)).sync(null);
     }
 
     @Test
@@ -262,8 +258,8 @@ public class SyncManagerTest {
     @Test
     public void progress_ShouldUpdateLastSyncTime_failure() {
         long lastSyncedTime = 10000L;
-        when(sharedPreferences.getLong(eq(SyncManager.KEY_LAST_SYNC_TIME), anyLong()))
-                .thenReturn(lastSyncedTime);
+        setLastSynced(lastSyncedTime);
+
         when(familyRepository.sync(any())).thenReturn(true);
         when(surveyRepository.sync(any())).thenReturn(true);
         when(snapshotRepository.sync(any())).thenReturn(false);
@@ -279,8 +275,7 @@ public class SyncManagerTest {
     @Test
     public void progress_ShouldUpdateLastSyncTime_clean() {
         long lastSyncedTime = 10000L;
-        when(sharedPreferences.getLong(eq(SyncManager.KEY_LAST_SYNC_TIME), anyLong()))
-                .thenReturn(lastSyncedTime);
+        setLastSynced(lastSyncedTime);
 
         SyncManager syncManager = syncManager();
         syncManager.clean();
@@ -325,16 +320,22 @@ public class SyncManagerTest {
         assertThat(syncManager.getProgress().getValue().getSyncState(), is(NEVER));
     }
 
+    private void setNeverSynced() {
+        when(sharedPreferences.getLong(eq(SyncManager.KEY_LAST_SYNC_TIME), anyLong()))
+                .thenAnswer(i ->  i.getArguments()[1]);
+    }
+
+    private void setLastSynced(long lastSyncedTime) {
+        when(sharedPreferences.getLong(eq(SyncManager.KEY_LAST_SYNC_TIME), anyLong()))
+                .thenReturn(lastSyncedTime);
+    }
+
     private void setOnline() {
         isOnline.postValue(true);
     }
 
     private void setOffline() {
         isOnline.postValue(false);
-    }
-
-    private Date date() {
-        return new Date(0L);
     }
 
     private SyncManager syncManager() {


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Description <!-- [OPTIONAL] -->
<!-- Include a short description of this pull request -->
Reduces the weight of syncing my only syncing families and surveys that have been created since the last sync time.

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Uses the last sync time to get newly updated families and surveys
  - Sync process adds the last sync time to the request to the REST server
  - Uses a error window of 1 day to ensure nothing strange happens with missing families/surveys
    - The last sync time is the end of last sync, where request was made at an unknown time before that (assuming here that the syncing process never lasted more than one day)
    - Also helps with avoiding issues related to time being changed on a device since last sync
- Adds a last modified field to family
  - Adds a very rough estimate of the families last modified time (basically is the last synced time)

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [X] Logged in to the application
  - [X] Fill out a snapshot for a new family
  - [X] Fill out a snapshot for an existing family
  - [X] Fill out priorities for a snapshot
  - [X] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [X] API Level 22
  - [ ] API Level 25
- Screen Size:
  - [ ] 7" screen size
  - [X] 8" screen size
  - [ ] 10" screen size
