### PR TITLE
Hotfix/cannot add priorities

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/IrMapper.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/IrMapper.java
@@ -5,6 +5,7 @@ import org.fundacionparaguaya.advisorapp.models.*;
 import java.text.*;
 import java.util.*;
 
+import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static org.fundacionparaguaya.advisorapp.models.BackgroundQuestion.QuestionType.ECONOMIC;
 import static org.fundacionparaguaya.advisorapp.models.BackgroundQuestion.QuestionType.PERSONAL;
 import static org.fundacionparaguaya.advisorapp.models.IndicatorOption.Level.*;
@@ -258,9 +259,10 @@ public class IrMapper {
         PriorityIr ir = new PriorityIr();
         ir.indicatorTitle = mapIndicatorName(priority.getIndicator());
         ir.snapshotId = snapshot.getRemoteId();
-        ir.reason = priority.getReason();
-        ir.action = priority.getAction();
+        ir.reason = defaultIfEmpty(priority.getReason(), "");
+        ir.action = defaultIfEmpty(priority.getAction(), "");
         ir.estimatedDate = mapDate(priority.getEstimatedDate());
+        ir.isCompleted = false; // required field, not supported yet by application
         return ir;
     }
 

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/PriorityIr.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/PriorityIr.java
@@ -22,6 +22,8 @@ public class PriorityIr {
     String action;
     @SerializedName("estimated_date")
     String estimatedDate;
+    @SerializedName("is_attainment")
+    boolean isCompleted;
 
     @Override
     public boolean equals(Object o) {
@@ -37,6 +39,7 @@ public class PriorityIr {
                 .append(reason, that.reason)
                 .append(action, that.action)
                 .append(estimatedDate, that.estimatedDate)
+                .append(isCompleted, that.isCompleted)
                 .isEquals();
     }
 
@@ -49,6 +52,7 @@ public class PriorityIr {
                 .append(reason)
                 .append(action)
                 .append(estimatedDate)
+                .append(isCompleted)
                 .toHashCode();
     }
 }


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Description <!-- [OPTIONAL] -->
<!-- Include a short description of this pull request -->
Fixes an issue with adding priorities on the newest version of the REST server, caused by a new required field on priorities called `is_attainment` (i.e. a priority that has been achieved, used to mark an indicator that someone is proud of).

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Adds the new field to the REST request, with a value of `false`
  - No additional support for UI or model is added

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [X] Logged in to the application
  - [X] Fill out a snapshot for a new family
  - [X] Fill out a snapshot for an existing family
  - [X] Fill out priorities for a snapshot
  - [X] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [X] API Level 22
  - [ ] API Level 25
- Screen Size:
  - [ ] 7" screen size
  - [X] 8" screen size
  - [ ] 10" screen size
