### PR TITLE
Change date modified to use last time it was synced

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/FamilyRepository.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/repositories/FamilyRepository.java
@@ -109,7 +109,7 @@ public class FamilyRepository {
                 Family old = familyDao.queryRemoteFamilyNow(family.getRemoteId());
                 if (old != null) {
                     family.setId(old.getId());
-                    family.setLastModified(lastSync); // TODO: Replace with last modified from server
+                    family.setLastModified(new Date()); // TODO: Replace with last modified from server
                 }
                 saveFamily(family);
             }


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Fixes an issue where family snapshots weren't synced on first sync
  - Affected families who were existing in DB before first log in
  - Changes last modified on the family to be the last time they were synced

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [X] Logged in to the application
  - [ ] Fill out a snapshot for a new family
  - [ ] Fill out a snapshot for an existing family
  - [ ] Fill out priorities for a snapshot
  - [X] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [X] API Level 22
  - [ ] API Level 25
- Screen Size:
  - [ ] 7" screen size
  - [X] 8" screen size
  - [ ] 10" screen size
