### PR TITLE
Feature: family picture backend

### DIFF
--- a/app/schemas/org.fundacionparaguaya.advisorapp.data.local.LocalDatabase/5.json
+++ b/app/schemas/org.fundacionparaguaya.advisorapp.data.local.LocalDatabase/5.json
@@ -1,0 +1,353 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "45a6b02078c79b704a805605d3392d0d",
+    "entities": [
+      {
+        "tableName": "families",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remote_id` INTEGER, `name` TEXT, `code` TEXT, `address` TEXT, `is_active` INTEGER NOT NULL, `last_modified` INTEGER, `image_url` TEXT, `longitude` REAL, `latitude` REAL, `city_id` INTEGER, `city_name` TEXT, `country_id` INTEGER, `country_name` TEXT, `family_member_first_name` TEXT, `family_member_last_name` TEXT, `family_member_birthdate` TEXT, `family_member_phone_number` TEXT, `family_member_identification_type` TEXT, `family_member_identification_number` TEXT, `family_member_gender` TEXT, `family_member_country_of_birth` TEXT, `family_member_profile_url` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "last_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.city.id",
+            "columnName": "city_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.city.name",
+            "columnName": "city_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.country.id",
+            "columnName": "country_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.country.name",
+            "columnName": "country_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.firstName",
+            "columnName": "family_member_first_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.lastName",
+            "columnName": "family_member_last_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.birthdate",
+            "columnName": "family_member_birthdate",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.phoneNumber",
+            "columnName": "family_member_phone_number",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.identificationType",
+            "columnName": "family_member_identification_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.identificationNumber",
+            "columnName": "family_member_identification_number",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.gender",
+            "columnName": "family_member_gender",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.countryOfBirth",
+            "columnName": "family_member_country_of_birth",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "member.profileUrl",
+            "columnName": "family_member_profile_url",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_families_remote_id",
+            "unique": true,
+            "columnNames": [
+              "remote_id"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_families_remote_id` ON `${TABLE_NAME}` (`remote_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "surveys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remote_id` INTEGER, `title` TEXT, `description` TEXT, `personal_questions` TEXT, `economic_questions` TEXT, `indicator_questions` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "personalQuestions",
+            "columnName": "personal_questions",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "economicQuestions",
+            "columnName": "economic_questions",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "indicatorQuestions",
+            "columnName": "indicator_questions",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_surveys_remote_id",
+            "unique": true,
+            "columnNames": [
+              "remote_id"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_surveys_remote_id` ON `${TABLE_NAME}` (`remote_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remote_id` INTEGER, `family_id` INTEGER, `survey_id` INTEGER NOT NULL, `in_progress` INTEGER NOT NULL, `personal_responses` TEXT, `economic_responses` TEXT, `indicator_responses` TEXT, `priorities` TEXT, `created_at` INTEGER, FOREIGN KEY(`family_id`) REFERENCES `families`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`survey_id`) REFERENCES `surveys`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "familyId",
+            "columnName": "family_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "surveyId",
+            "columnName": "survey_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inProgress",
+            "columnName": "in_progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personalResponses",
+            "columnName": "personal_responses",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "economicResponses",
+            "columnName": "economic_responses",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "indicatorResponses",
+            "columnName": "indicator_responses",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priorities",
+            "columnName": "priorities",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_snapshots_family_id",
+            "unique": false,
+            "columnNames": [
+              "family_id"
+            ],
+            "createSql": "CREATE  INDEX `index_snapshots_family_id` ON `${TABLE_NAME}` (`family_id`)"
+          },
+          {
+            "name": "index_snapshots_survey_id",
+            "unique": false,
+            "columnNames": [
+              "survey_id"
+            ],
+            "createSql": "CREATE  INDEX `index_snapshots_survey_id` ON `${TABLE_NAME}` (`survey_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "families",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "family_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "surveys",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "survey_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"45a6b02078c79b704a805605d3392d0d\")"
+    ]
+  }
+}

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/adapters/FamiliesAdapter.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/adapters/FamiliesAdapter.java
@@ -63,9 +63,12 @@ public class FamiliesAdapter extends RecyclerView.Adapter<FamiliesAdapter.Family
                 holder.familyPhone.setText(family.getMember().getPhoneNumber());
             }
         }
-        Uri uri = Uri.parse("https://s3.us-east-2.amazonaws.com/fp-psp-images/44-3.jpg");
 
-        holder.imageView.setImageURI(uri);
+        if (family.getImageUrl() != null && !family.getImageUrl().isEmpty()) {
+            Uri uri = Uri.parse(family.getImageUrl());
+            holder.imageView.setImageURI(uri);
+        }
+
 
         holder.itemView.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/local/LocalDatabase.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/local/LocalDatabase.java
@@ -13,7 +13,7 @@ import org.fundacionparaguaya.advisorapp.models.Survey;
 /**
  * The database storing a local cache of data for the user.
  */
-@Database(entities = {Family.class, Survey.class, Snapshot.class}, version = 4)
+@Database(entities = {Family.class, Survey.class, Snapshot.class}, version = 5)
 public abstract class LocalDatabase extends RoomDatabase {
 
     private static final Migration MIGRATION_2_3 = new Migration(2, 3) {
@@ -32,9 +32,18 @@ public abstract class LocalDatabase extends RoomDatabase {
         }
     };
 
+    private static final Migration MIGRATION_4_5 = new Migration(4, 5) {
+        @Override
+        public void migrate(@NonNull SupportSQLiteDatabase database) {
+            database.execSQL("ALTER TABLE families "
+                    + " ADD COLUMN image_url TEXT DEFAULT null");
+        }
+    };
+
     public static final Migration[] MIGRATIONS = new Migration[] {
             MIGRATION_2_3,
-            MIGRATION_3_4
+            MIGRATION_3_4,
+            MIGRATION_4_5
     };
 
     public abstract FamilyDao familyDao();

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/SnapshotService.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/SnapshotService.java
@@ -7,10 +7,13 @@ import org.fundacionparaguaya.advisorapp.data.remote.intermediaterepresentation.
 
 import java.util.List;
 
+import okhttp3.MultipartBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
+import retrofit2.http.PUT;
+import retrofit2.http.Part;
 import retrofit2.http.Query;
 
 /**
@@ -43,4 +46,9 @@ public interface SnapshotService {
     @POST("snapshots/priority")
     Call<PriorityIr> postPriority(
             @Body PriorityIr priorityIr);
+
+    //region Temporary upload image for demo
+    @PUT("families/{id}/image")
+    Call<String> putFamilyPicture(@Part MultipartBody.Part file);
+    //endregion Temporary upload image for demo
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/FamilyIr.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/FamilyIr.java
@@ -17,4 +17,6 @@ public class FamilyIr {
     FamilyMemberIr member;
     @SerializedName("active")
     boolean active;
+    @SerializedName("imageURL")
+    String imageUrl;
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/IrMapper.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/IrMapper.java
@@ -41,6 +41,7 @@ public class IrMapper {
                 .name(ir.name)
                 .code(ir.code)
                 .member(mapFamilyMember(ir.member))
+                .imageUrl(ir.imageUrl)
                 .build();
     }
 

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/IrMapper.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/IrMapper.java
@@ -165,7 +165,11 @@ public class IrMapper {
                 } else if (fieldIr != null
                         && "gmap".equals(fieldIr.field)) {
                     return ResponseType.LOCATION;
+                } else if (fieldIr != null
+                        && "photo".equals(fieldIr.field)) {
+                    return ResponseType.PHOTO;
                 }
+
                 return ResponseType.STRING;
             case "number":
                 return ResponseType.INTEGER;

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/fragments/FamilyDetailFrag.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/fragments/FamilyDetailFrag.java
@@ -10,7 +10,10 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.TabLayout;
-import android.support.v4.app.*;
+import android.support.v4.app.ActivityOptionsCompat;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -34,10 +37,11 @@ import org.fundacionparaguaya.advisorapp.util.MixpanelHelper;
 import org.fundacionparaguaya.advisorapp.viewmodels.FamilyDetailViewModel;
 import org.fundacionparaguaya.advisorapp.viewmodels.InjectionViewModelFactory;
 
-import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import javax.inject.Inject;
 
 
 public class FamilyDetailFrag extends AbstractStackedFrag implements Observer<Family>, LifeMapFragmentCallback {
@@ -128,9 +132,6 @@ public class FamilyDetailFrag extends AbstractStackedFrag implements Observer<Fa
         {
             Log.e(FamilyDetailFrag.class.getName(), e.getMessage());
         }
-
-        Uri uri = Uri.parse(getString(R.string.family_imagePlaceholder));
-        mFamilyImage.setImageURI(uri);
     }
 
     @Override
@@ -161,6 +162,10 @@ public class FamilyDetailFrag extends AbstractStackedFrag implements Observer<Fa
             mPhoneNumber.setText(getText(R.string.familydetails_phonenumberdefault));
         }
 
+        if (mFamilyInformationViewModel.hasImageUri()) {
+            Uri uri = mFamilyInformationViewModel.getImageUri();
+            mFamilyImage.setImageURI(uri);
+        }
     }
 
     public static FamilyDetailFrag build(int familyId)

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/models/Family.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/models/Family.java
@@ -40,6 +40,8 @@ public class Family {
     private Location location;
     @Embedded(prefix = "family_member_")
     private FamilyMember member;
+    @ColumnInfo(name="image_url")
+    private String imageUrl;
 
     /**
      * Creates a new family. You should use the {@link Family#builder()} to construct a new family instead.
@@ -51,6 +53,7 @@ public class Family {
                   String address,
                   Location location,
                   FamilyMember member,
+                  String imageUrl,
                   boolean isActive,
                   Date lastModified) {
         this.id = id;
@@ -60,6 +63,7 @@ public class Family {
         this.address = address;
         this.location = location;
         this.member = member;
+        this.imageUrl = imageUrl;
         this.isActive = isActive;
         this.lastModified = lastModified;
     }
@@ -110,6 +114,14 @@ public class Family {
         return location;
     }
 
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
     public void setLastModified(Date lastModified) {
         this.lastModified = lastModified;
     }
@@ -141,6 +153,7 @@ public class Family {
                 .append(isActive, that.isActive)
                 .append(location, that.location)
                 .append(member, that.member)
+                .append(imageUrl, that.imageUrl)
                 .isEquals();
     }
 
@@ -156,6 +169,7 @@ public class Family {
                 .append(isActive)
                 .append(location)
                 .append(member)
+                .append(imageUrl)
                 .toHashCode();
     }
 
@@ -169,6 +183,7 @@ public class Family {
         private FamilyMember member;
         private boolean isActive = true;
         private Date lastModified;
+        private String imageUrl;
 
         /**
          * Sets the ID of the new family. Should only be used if overwriting an existing family!
@@ -208,6 +223,11 @@ public class Family {
             return this;
         }
 
+        public Builder imageUrl(String imageUrl) {
+            this.imageUrl = imageUrl;
+            return this;
+        }
+
         public Builder isActive(boolean isActive) {
             this.isActive = isActive;
             return this;
@@ -237,7 +257,7 @@ public class Family {
         }
 
         public Family build() {
-            return new Family(id, remoteId, name, code, address, location, member, isActive, lastModified);
+            return new Family(id, remoteId, name, code, address, location, member, imageUrl, isActive, lastModified);
         }
     }
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/viewmodels/FamilyDetailViewModel.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/viewmodels/FamilyDetailViewModel.java
@@ -4,16 +4,22 @@ import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
 import android.arch.lifecycle.Transformations;
 import android.arch.lifecycle.ViewModel;
+import android.net.Uri;
 
 import com.instabug.library.Instabug;
 
 import org.fundacionparaguaya.advisorapp.BuildConfig;
-import org.fundacionparaguaya.advisorapp.models.*;
+import org.fundacionparaguaya.advisorapp.models.Family;
+import org.fundacionparaguaya.advisorapp.models.Indicator;
+import org.fundacionparaguaya.advisorapp.models.IndicatorOption;
+import org.fundacionparaguaya.advisorapp.models.LifeMapPriority;
+import org.fundacionparaguaya.advisorapp.models.Snapshot;
 import org.fundacionparaguaya.advisorapp.repositories.FamilyRepository;
 import org.fundacionparaguaya.advisorapp.repositories.SnapshotRepository;
 import org.fundacionparaguaya.advisorapp.util.IndicatorUtilities;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
 
 
 public class FamilyDetailViewModel extends ViewModel {
@@ -144,5 +150,24 @@ public class FamilyDetailViewModel extends ViewModel {
      */
     public LiveData<Collection<IndicatorOption>> getSnapshotIndicators() {
         return mIndicatorsForSelected;
+    }
+
+    public boolean hasImageUri() {
+        Family family = getCurrentFamily().getValue();
+        if (family == null || family.getImageUrl() == null || family.getImageUrl().isEmpty()) {
+            return false;
+        }
+        return true;
+    }
+
+    public Uri getImageUri() {
+        Uri uri;
+        Family family = getCurrentFamily().getValue();
+        if (family != null && family.getImageUrl() != null && !family.getImageUrl().isEmpty()) {
+            uri = Uri.parse(family.getImageUrl());
+        } else {
+            uri = Uri.parse("https://s3.us-east-2.amazonaws.com/fp-psp-images/44-3.jpg");
+        }
+        return uri;
     }
 }


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Adds pictures to the family
  - The family now has an `imageUrl` field which is populated by the server
  - Family cards now use this new image when available, or fallback to default otherwise
- Support for a `familyPicture` was added on backend
   - Uploads the image to server in a temporary fashion for demo
   - Doesn't add UI support

# Screenshots <!-- [IF APPLICABLE] -->
<!-- If this change involves any visible changes, include screenshots of key screens here -->
![image](https://user-images.githubusercontent.com/1918630/37907773-0d200688-30d4-11e8-8eb9-b6aa93f8847d.png)
![image](https://user-images.githubusercontent.com/1918630/37907780-1333746a-30d4-11e8-8979-0a89595d1713.png)


# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [X] Logged in to the application
  - [X] Fill out a snapshot for a new family
  - [ ] Fill out a snapshot for an existing family
  - [X] Fill out priorities for a snapshot
  - [X] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [X] API Level 22
  - [ ] API Level 25
- Screen Size:
  - [ ] 7" screen size
  - [X] 8" screen size
  - [ ] 10" screen size
