### PR TITLE
Fixed problem with keyboard hiding and view not animating down/out

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/activities/EditPriorityActivity.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/activities/EditPriorityActivity.java
@@ -19,6 +19,7 @@ import org.fundacionparaguaya.advisorapp.AdvisorApplication;
 import org.fundacionparaguaya.advisorapp.R;
 import org.fundacionparaguaya.advisorapp.models.*;
 import org.fundacionparaguaya.advisorapp.util.IndicatorUtilities;
+import org.fundacionparaguaya.advisorapp.util.KeyboardUtils;
 import org.fundacionparaguaya.advisorapp.viewcomponents.NumberStepperView;
 import org.fundacionparaguaya.advisorapp.viewmodels.EditPriorityViewModel;
 import org.fundacionparaguaya.advisorapp.viewmodels.InjectionViewModelFactory;
@@ -73,7 +74,7 @@ public class EditPriorityActivity extends FragmentActivity implements View.OnCli
 
     protected void onPause()
     {
-        overridePendingTransition(R.anim.slide_down, R.anim.stay);
+        overridePendingTransition(R.anim.stay, R.anim.slide_down);
         super.onPause();
     }
 
@@ -153,6 +154,10 @@ public class EditPriorityActivity extends FragmentActivity implements View.OnCli
 
     @Override
     public void onClick(View view) {
+        if(this.getCurrentFocus()!=null) {
+            KeyboardUtils.hideKeyboard(this.getCurrentFocus(),this);
+        }
+
         if(view.equals(mBtnExit))
         {
             setResult(Activity.RESULT_CANCELED);
@@ -170,7 +175,7 @@ public class EditPriorityActivity extends FragmentActivity implements View.OnCli
             //endRegion
 
             setResult(Activity.RESULT_OK, result);
-            supportFinishAfterTransition();
+            this.finish();
         }
     }
 

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/activities/SurveyActivity.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/activities/SurveyActivity.java
@@ -25,10 +25,6 @@ import javax.inject.Inject;
 
 public class SurveyActivity extends AbstractFragSwitcherActivity
 {
-    //Always Show: The header will always be present in the fragment, regardless of the keyboard state
-    //Always Hide: The header will always be hidden from the fragment
-    //Always AutoHide, the header will usually be shown, but will hide when the keyboard comes up
-
     static String FAMILY_ID_KEY = "FAMILY_ID";
 
     private ImageButton mExitButton;

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/fragments/TakeSurveyFragment.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/fragments/TakeSurveyFragment.java
@@ -17,6 +17,7 @@ import com.stepstone.stepper.VerificationError;
 import org.fundacionparaguaya.advisorapp.AdvisorApplication;
 import org.fundacionparaguaya.advisorapp.R;
 import org.fundacionparaguaya.advisorapp.adapters.SurveyTabPagerAdapter;
+import org.fundacionparaguaya.advisorapp.util.KeyboardUtils;
 import org.fundacionparaguaya.advisorapp.viewmodels.InjectionViewModelFactory;
 import org.fundacionparaguaya.advisorapp.viewmodels.SharedSurveyViewModel;
 import org.fundacionparaguaya.advisorapp.viewmodels.SharedSurveyViewModel.SurveyState;
@@ -91,12 +92,13 @@ public class TakeSurveyFragment extends Fragment implements  StepperLayout.Stepp
 
                         case INDICATORS:
                             title = getResources().getString(R.string.survey_summary_indicatortitle);
-                            hideKeyboard();
+                            KeyboardUtils.hideKeyboard(mStepperLayout, getActivity());
                             getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
                             break;
 
                         case LIFEMAP:
                             title = getResources().getString(R.string.life_map_title);
+                            KeyboardUtils.hideKeyboard(mStepperLayout, getActivity());
                             getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
                             break;
 
@@ -128,14 +130,6 @@ public class TakeSurveyFragment extends Fragment implements  StepperLayout.Stepp
         });
 
         return view;
-    }
-
-    public void hideKeyboard() {
-        View view = mStepperLayout;
-        if (view != null) {
-            InputMethodManager imm = (InputMethodManager)getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
-            imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
-        }
     }
 
     /**

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/util/KeyboardUtils.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/util/KeyboardUtils.java
@@ -1,0 +1,19 @@
+package org.fundacionparaguaya.advisorapp.util;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
+
+/**
+ * Utilities Relating to the Keyboard
+ */
+
+public class KeyboardUtils {
+    public static void hideKeyboard(View view, Activity activity) {
+        if (view != null) {
+            InputMethodManager imm = (InputMethodManager)activity.getSystemService(Context.INPUT_METHOD_SERVICE);
+            imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+        }
+    }
+}

--- a/app/src/main/res/anim/slide_down.xml
+++ b/app/src/main/res/anim/slide_down.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <translate xmlns:android="http://schemas.android.com/apk/res/android"
            android:duration="@android:integer/config_longAnimTime"
-           android:fromYDelta="-100%p"
-           android:toYDelta="0%p" />
+           android:fromYDelta="0%p"
+           android:toYDelta="100%p" />


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Description <!-- [OPTIONAL] -->
<!-- Include a short description of this pull request -->
Made keyboard hide on the life map page, specifically when returning from editing a priority.

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Made keyboard util class to easily reuse logic
- Made keyboard hide when returning from activity
- Fixed slide down animation (looks great now!)

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [ ] Logged in to the application
  - [X] Fill out a snapshot for a new family
  - [X] Fill out a snapshot for an existing family
  - [X] Fill out priorities for a snapshot
  - [ ] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [ ] API Level 22
  - [X] API Level 25
- Screen Size:
  - [ ] 7" screen size
  - [X] 8" screen size
  - [ ] 10" screen size
