### PR TITLE
 Add backend support for achieved priorities

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/model/LifeMapPriority.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/model/LifeMapPriority.java
@@ -20,12 +20,16 @@ public class LifeMapPriority {
     private String action;
     @ColumnInfo(name = "estimated_date")
     private Date estimatedDate;
+    @ColumnInfo(name = "is_achievement")
+    private boolean isAchievement;
 
-    public LifeMapPriority(Indicator indicator, String reason, String action, Date estimatedDate) {
+    public LifeMapPriority(Indicator indicator, String reason, String action, Date estimatedDate,
+                           boolean isAchievement) {
         this.indicator = indicator;
         this.reason = reason;
         this.action = action;
         this.estimatedDate = estimatedDate;
+        this.isAchievement = isAchievement;
     }
 
     public Indicator getIndicator() {
@@ -36,31 +40,36 @@ public class LifeMapPriority {
         return reason;
     }
 
+    public void setReason(String s) {
+        this.reason = s;
+    }
+
     public String getAction() {
         return action;
+    }
+
+    public void setAction(String s) {
+        this.action = s;
     }
 
     public Date getEstimatedDate() {
         return estimatedDate;
     }
 
+    public void setEstimatedDate(Date when) {
+        this.estimatedDate = when;
+    }
+
+    public boolean isAchievement() {
+        return isAchievement;
+    }
+
+    public void setAchievement(boolean achievement) {
+        isAchievement = achievement;
+    }
+
     public static Builder builder() {
         return new Builder();
-    }
-
-    public void setReason(String s)
-    {
-        this.reason = s;
-    }
-
-    public void setStrategy(String s)
-    {
-        this.action = s;
-    }
-
-    public void setWhen(Date when)
-    {
-        this.estimatedDate = when;
     }
 
     @Override
@@ -93,6 +102,7 @@ public class LifeMapPriority {
         private String reason;
         private String action;
         private Date estimatedDate;
+        private boolean isAchievement;
 
         public Builder indicator(Indicator indicator) {
             this.indicator = indicator;
@@ -114,8 +124,13 @@ public class LifeMapPriority {
             return this;
         }
 
+        public Builder isAchievement(boolean isAchievement) {
+            this.isAchievement = isAchievement;
+            return this;
+        }
+
         public LifeMapPriority build() {
-            return new LifeMapPriority(indicator, reason, action, estimatedDate);
+            return new LifeMapPriority(indicator, reason, action, estimatedDate, isAchievement);
         }
     }
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/IrMapper.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/IrMapper.java
@@ -267,7 +267,7 @@ public class IrMapper {
         ir.reason = defaultIfEmpty(priority.getReason(), "");
         ir.action = defaultIfEmpty(priority.getAction(), "");
         ir.estimatedDate = mapDate(priority.getEstimatedDate());
-        ir.isCompleted = false; // required field, not supported yet by application
+        ir.isAchievement = priority.isAchievement();
         return ir;
     }
 
@@ -361,6 +361,7 @@ public class IrMapper {
                 .reason(ir.reason)
                 .action(ir.action)
                 .estimatedDate(mapDate(ir.estimatedDate))
+                .isAchievement(ir.isAchievement)
                 .build();
     }
 
@@ -411,6 +412,8 @@ public class IrMapper {
     }
 
     private static Date mapDate(String ir) {
+        if (ir == null) return null;
+
         TimeZone tz = TimeZone.getTimeZone("UTC");
         DateFormat df = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
         df.setTimeZone(tz);

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/PriorityIr.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/PriorityIr.java
@@ -23,7 +23,7 @@ public class PriorityIr {
     @SerializedName("estimated_date")
     String estimatedDate;
     @SerializedName("is_attainment")
-    boolean isCompleted;
+    boolean isAchievement;
 
     @Override
     public boolean equals(Object o) {
@@ -39,7 +39,7 @@ public class PriorityIr {
                 .append(reason, that.reason)
                 .append(action, that.action)
                 .append(estimatedDate, that.estimatedDate)
-                .append(isCompleted, that.isCompleted)
+                .append(isAchievement, that.isAchievement)
                 .isEquals();
     }
 
@@ -52,7 +52,7 @@ public class PriorityIr {
                 .append(reason)
                 .append(action)
                 .append(estimatedDate)
-                .append(isCompleted)
+                .append(isAchievement)
                 .toHashCode();
     }
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/survey/SharedSurveyViewModel.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/survey/SharedSurveyViewModel.java
@@ -242,8 +242,8 @@ public class SharedSurveyViewModel extends ViewModel {
             if(p.getIndicator().equals(newPriority.getIndicator()))
             {
                 p.setReason(newPriority.getReason());
-                p.setStrategy(newPriority.getAction());
-                p.setWhen(newPriority.getEstimatedDate());
+                p.setAction(newPriority.getAction());
+                p.setEstimatedDate(newPriority.getEstimatedDate());
             }
         }
 

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/survey/priorities/EditPriorityActivity.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/survey/priorities/EditPriorityActivity.java
@@ -15,16 +15,22 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.TextView;
+
 import org.fundacionparaguaya.advisorapp.AdvisorApplication;
 import org.fundacionparaguaya.advisorapp.R;
-import org.fundacionparaguaya.advisorapp.data.model.*;
+import org.fundacionparaguaya.advisorapp.data.model.Indicator;
+import org.fundacionparaguaya.advisorapp.data.model.IndicatorOption;
+import org.fundacionparaguaya.advisorapp.data.model.IndicatorQuestion;
+import org.fundacionparaguaya.advisorapp.data.model.LifeMapPriority;
+import org.fundacionparaguaya.advisorapp.data.model.Survey;
+import org.fundacionparaguaya.advisorapp.injection.InjectionViewModelFactory;
+import org.fundacionparaguaya.advisorapp.ui.common.widget.NumberStepperView;
 import org.fundacionparaguaya.advisorapp.util.IndicatorUtilities;
 import org.fundacionparaguaya.advisorapp.util.KeyboardUtils;
-import org.fundacionparaguaya.advisorapp.ui.common.widget.NumberStepperView;
-import org.fundacionparaguaya.advisorapp.injection.InjectionViewModelFactory;
+
+import java.util.Date;
 
 import javax.inject.Inject;
-import java.util.Date;
 
 /**
  * Pop up window that allows the user to input some details about the priority..
@@ -252,21 +258,14 @@ public class EditPriorityActivity extends FragmentActivity implements View.OnCli
 
     public static LifeMapPriority processResult(Intent result, Survey s)
     {
-        return processResult(result,
-                new LifeMapPriority
-                        (getIndicatorFromResult(result, s),
-                        "",
-                        "",
-                        null));
-    }
-
-    public static LifeMapPriority processResult(Intent result, LifeMapPriority p)
-    {
-        p.setReason(result.getStringExtra(RESPONSE_REASON_ARG));
-        p.setStrategy(result.getStringExtra(RESPONSE_ACTION_ARG));
-        p.setWhen((Date)result.getSerializableExtra(RESPONSE_DATE_ARG));
-
-        return p;
+        return LifeMapPriority.builder()
+                .indicator(getIndicatorFromResult(result, s))
+                .reason(result.getStringExtra(RESPONSE_REASON_ARG))
+                .action(result.getStringExtra(RESPONSE_ACTION_ARG))
+                .estimatedDate((Date)result.getSerializableExtra(RESPONSE_DATE_ARG))
+                .isAchievement(result.getStringExtra(INDICATOR_LEVEL_ARG).equals("Green"))
+                        //TODO: match to field determining whether this is an achievement
+                .build();
     }
     //endregion
 }

--- a/app/src/test/java/org/fundacionparaguaya/advisorapp/data/model/ModelUtils.java
+++ b/app/src/test/java/org/fundacionparaguaya/advisorapp/data/model/ModelUtils.java
@@ -98,7 +98,8 @@ public class ModelUtils {
         priorities.add(new LifeMapPriority(yellowIncomeOption.getIndicator(),
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                date("2018-02-13")));
+                date("2018-02-13"),
+                false));
 
         return new Snapshot(1, 1L, family.getId(), survey.getId(), false,
                 personalResponses, economicResponses, indicatorResponses, priorities,


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Adds backend support for priorities that a family is proud of
  - Adds a new field called `isAchievement` to `LifeMapPriority`
  - Synchronizes this new fields with the remote server
  - Supports syncing for priorities without an estimated date

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [X] Logged in to the application
  - [X] Fill out a snapshot for a new family
  - [ ] Fill out a snapshot for an existing family
  - [X] Fill out priorities for a snapshot
  - [X] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [X] API Level 22
  - [ ] API Level 25
- Screen Size:
  - [ ] 7" screen size
  - [X] 8" screen size
  - [ ] 10" screen size
