### PR TITLE
Refactor how login saves data when rotating

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/login/LoginViewModel.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/login/LoginViewModel.java
@@ -15,9 +15,17 @@ public class LoginViewModel extends ViewModel {
     private ServerManager mServerManager;
     private AuthenticationManager mAuthManager;
 
+    private String mUsername = "";
+    private String mPassword = "";
+
     public LoginViewModel(ServerManager serverManager, AuthenticationManager authManager) {
         this.mServerManager = serverManager;
         this.mAuthManager = authManager;
+    }
+
+    void clearPassword()
+    {
+        mPassword = "";
     }
 
     public AuthenticationManager getAuthManager() {
@@ -38,6 +46,22 @@ public class LoginViewModel extends ViewModel {
 
     public Server[] getServers() {
         return mServerManager.getServers();
+    }
+
+    public String getUsername(){
+        return mUsername;
+    }
+
+    public void setUsername(String username){
+        mUsername = username;
+    }
+
+    public String getPassword(){
+        return mPassword;
+    }
+
+    public void setPassword(String password){
+        mPassword = password;
     }
 }
 


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Description <!-- [OPTIONAL] -->
<!-- Include a short description of this pull request -->
Remove setRetainInstance from the LoginFragment, and implement saving for when app rotates through the viewmodel

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- remove setRetainInstance
- add strings for username and password to the viewmodel
- set username and password to viewmodel onchange
- get username and password from the viewmodel when authenticating

# Issues <!-- [IF APPLICABLE] -->
<!-- Fill in a bulleted list with issues that have been introduced or fixed -->
- Fixes #499 

# Screenshots <!-- [IF APPLICABLE] -->
<!-- If this change involves any visible changes, include screenshots of key screens here -->

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [x] Logged in to the application
  - [ ] Fill out a snapshot for a new family
  - [ ] Fill out a snapshot for an existing family
  - [ ] Fill out priorities for a snapshot
  - [ ] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [ ] API Level 22
  - [x] API Level 25
- Screen Size:
  - [ ] 7" screen size
  - [x] 8" screen size
  - [ ] 10" screen size
