### PR TITLE
Fixed activity + fragment memory leak on family detail page

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/injection/ApplicationComponent.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/injection/ApplicationComponent.java
@@ -3,7 +3,7 @@ package org.fundacionparaguaya.advisorapp.injection;
 import android.app.Application;
 
 import org.fundacionparaguaya.advisorapp.AdvisorApplication;
-import org.fundacionparaguaya.advisorapp.ui.common.PriorityListFrag;
+import org.fundacionparaguaya.advisorapp.ui.survey.priorities.PriorityListFrag;
 import org.fundacionparaguaya.advisorapp.ui.dashboard.DashActivity;
 import org.fundacionparaguaya.advisorapp.ui.families.detail.FamilyDetailFrag;
 import org.fundacionparaguaya.advisorapp.ui.families.detail.FamilyLifeMapFragment;

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/common/PrioritiesListAdapter.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/common/PrioritiesListAdapter.java
@@ -21,6 +21,7 @@ import java.util.List;
 /**
  * Adapter for Priorities List Fragment
  *
+ * This adapter was written improperly. See issue
  */
 
 public class PrioritiesListAdapter extends RecyclerView.Adapter<PrioritiesListAdapter.PrioritiesListViewHolder> {
@@ -60,11 +61,9 @@ public class PrioritiesListAdapter extends RecyclerView.Adapter<PrioritiesListAd
 
         holder.itemView.setOnClickListener(v -> setSelected(holder.getPriority()));
 
-        mViewHolderList.add(holder);
+        if(mPriorities.get(position).equals(mSelectedPriority)) holder.setSelected(true);
 
-        if (mSelectedPriority == null && position == 0) {
-            setSelected(holder.getPriority());
-        }
+        mViewHolderList.add(holder);
     }
 
     @Override
@@ -74,18 +73,21 @@ public class PrioritiesListAdapter extends RecyclerView.Adapter<PrioritiesListAd
 
     //TODO: this causes views not to be recycled (issue #
     public void setSelected(LifeMapPriority priority){
-        mSelectedPriority = priority;
+        if(mSelectedPriority != priority) {
+            mSelectedPriority = priority;
 
-        //Set only 1 to selected, everything else is not selected
-        for (PrioritiesListViewHolder viewHolder : mViewHolderList){
-            if (viewHolder.getPriority().equals(priority)){
-                viewHolder.setSelected(true);
-            } else {
-                viewHolder.setSelected(false);
+            //Set only 1 to selected, everything else is not selected
+            for (PrioritiesListViewHolder viewHolder : mViewHolderList) {
+                if (viewHolder.getPriority().equals(priority)) {
+                    viewHolder.setSelected(true);
+                }
+                else {
+                    viewHolder.setSelected(false);
+                }
             }
-        }
 
-        notifyHandlers(mSelectedPriority);
+            notifyHandlers(mSelectedPriority);
+        }
     }
 
     //region Item Selection

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/common/widget/EvenBetterSpinner.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/common/widget/EvenBetterSpinner.java
@@ -80,9 +80,8 @@ public class EvenBetterSpinner extends BetterSpinner {
         if(getAdapter().getCount()>0)
         {
             setSelectedPosition(0);
+            onItemClick(null, null, getSelectedPosition(), this.getId());
         }
-
-        onItemClick(null, null, getSelectedPosition(), this.getId());
     }
     @Override
     protected void onTextChanged(CharSequence text, int start, int lengthBefore, int lengthAfter) {

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/families/detail/FamilyDetailFrag.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/families/detail/FamilyDetailFrag.java
@@ -63,6 +63,8 @@ public class FamilyDetailFrag extends AbstractStackedFrag implements Observer<Fa
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState){
 
+        super.onCreate(savedInstanceState);
+
         ((AdvisorApplication) getActivity().getApplication())
                 .getApplicationComponent()
                 .inject(this);
@@ -71,13 +73,13 @@ public class FamilyDetailFrag extends AbstractStackedFrag implements Observer<Fa
                .of(this, mViewModelFactory)
                 .get(FamilyDetailViewModel.class);
 
-        if (getArguments() != null) {
+        if (savedInstanceState==null && getArguments() != null) {
             Bundle args = getArguments();
             mFamilyId = args.getInt(SELECTED_FAMILY_KEY);
             mFamilyInformationViewModel.setFamily(mFamilyId);
             //wait for family to load here
         }
-        else
+        else if(getArguments() == null)
         {
             throw new IllegalArgumentException(FamilyDetailFrag.class.getName() + " requires the family id to be displayed" +
                     "to be passed in as an argument.");
@@ -86,9 +88,6 @@ public class FamilyDetailFrag extends AbstractStackedFrag implements Observer<Fa
         mFamilyInformationViewModel.getSnapshotIndicators().observe(this, indicatorOptions -> {
             Log.d("", "Updated");
         });
-
-        super.onCreate(savedInstanceState); //must be called after the view model is instantiated (because the
-                                            //super oncreate will create the child fragments
     }
 
     @Override
@@ -110,11 +109,8 @@ public class FamilyDetailFrag extends AbstractStackedFrag implements Observer<Fa
         mFamilyImage = view.findViewById(R.id.family_image_2);
 
         ViewPager viewPager = view.findViewById(R.id.pager_familydetail);
-        ViewPagerAdapter adapter = new ViewPagerAdapter(getChildFragmentManager());
+        FamilyViewPagerAdapter adapter = new FamilyViewPagerAdapter(getChildFragmentManager());
 
-        // Add Fragments to adapter one by one
-        adapter.addFragment(new FamilyLifeMapFragment(), getResources().getString(R.string.life_map_title));
-        adapter.addFragment(new FamilyPrioritiesFrag(), getResources().getString(R.string.priorities));
 
         viewPager.setAdapter(adapter);
 
@@ -216,32 +212,45 @@ public class FamilyDetailFrag extends AbstractStackedFrag implements Observer<Fa
 
     }
 
-    class ViewPagerAdapter extends FragmentPagerAdapter {
-        private final List<Fragment> mFragmentList = new ArrayList<>();
-        private final List<String> mFragmentTitleList = new ArrayList<>();
-
-        public ViewPagerAdapter(FragmentManager manager) {
+    class FamilyViewPagerAdapter extends FragmentPagerAdapter {
+        FamilyViewPagerAdapter(FragmentManager manager) {
             super(manager);
         }
 
         @Override
         public Fragment getItem(int position) {
-            return mFragmentList.get(position);
+            switch (position)
+            {
+                case 0:
+                    return new FamilyLifeMapFragment();
+
+                case 1:
+                    return new FamilyPrioritiesFrag();
+
+                default:
+                    return null;
+            }
         }
 
         @Override
         public int getCount() {
-            return mFragmentList.size();
-        }
-
-        public void addFragment(Fragment fragment, String title) {
-            mFragmentList.add(fragment);
-            mFragmentTitleList.add(title);
+            return 2;
         }
 
         @Override
         public CharSequence getPageTitle(int position) {
-            return mFragmentTitleList.get(position);
+
+            switch (position)
+            {
+                case 0:
+                    return getResources().getString(R.string.life_map_title);
+
+                case 1:
+                    return getResources().getString(R.string.priorities);
+
+                default:
+                    return null;
+            }
         }
     }
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/families/detail/FamilyLifeMapFragment.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/families/detail/FamilyLifeMapFragment.java
@@ -91,13 +91,7 @@ public class FamilyLifeMapFragment extends Fragment implements LifeMapFragmentCa
     public void removeViewModelObservers()
     {
         mFamilyDetailViewModel.getSnapshots().removeObservers(this);
-        mFamilyDetailViewModel.getSelectedSnapshot().removeObservers(this);
-    }
-
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-        removeViewModelObservers();
+        mFamilyDetailViewModel.SelectedSnapshot().removeObservers(this);
     }
 
     public void addViewModelObservers()
@@ -106,23 +100,21 @@ public class FamilyLifeMapFragment extends Fragment implements LifeMapFragmentCa
             //This is necessary to completely clear the Array Adapter every time snapshots get updated
             mSpinnerAdapter = new ArrayAdapter<>(this.getContext(), R.layout.item_tv_spinner);
             mSnapshotSpinner.setAdapter(mSpinnerAdapter);
+
             if(snapshots!=null) {
                 mSpinnerAdapter.addAll(snapshots);
-                mSpinnerAdapter.sort((o1, o2) -> o2.getCreatedAt().compareTo(o1.getCreatedAt())); //switched o2/o1 to sort descending
-                Snapshot s = mFamilyDetailViewModel.getSelectedSnapshot().getValue();
-                if(mSpinnerAdapter.getCount() > 0) {
-                    if (mFamilyDetailViewModel.getSelectedSnapshot().getValue() != null){
-                        mSnapshotSpinner.setSelectedPosition(mSpinnerAdapter.getPosition(
-                                mFamilyDetailViewModel.getSelectedSnapshot().getValue()));
-                    } else {
-                        mFamilyDetailViewModel.setSelectedSnapshot(mSpinnerAdapter.getItem(0));
-                    }
-                }
-            }
-        });
+                mFamilyDetailViewModel.SelectedSnapshot().removeObservers(this);
 
-        mFamilyDetailViewModel.getSelectedSnapshot().observe(this, (snapshot) -> {
-            mSnapshotSpinner.setSelectedPosition(mSpinnerAdapter.getPosition(snapshot));
+                mFamilyDetailViewModel.SelectedSnapshot().observe(this, (snapshot) -> {
+                    if(snapshot == null) {
+                        mFamilyDetailViewModel.selectFirstSnapshot();
+                    }
+                    else
+                    {
+                        mSnapshotSpinner.setSelectedPosition(mSpinnerAdapter.getPosition(snapshot));
+                    }
+                });
+            }
         });
     }
 
@@ -139,5 +131,13 @@ public class FamilyLifeMapFragment extends Fragment implements LifeMapFragmentCa
     @Override
     public void onLifeMapIndicatorClicked(LifeMapAdapter.LifeMapIndicatorClickedEvent e) {
 
+    }
+
+    @Override
+    public void onDestroyView() {
+        removeViewModelObservers();
+        mSnapshotSpinner = null;
+
+        super.onDestroyView();
     }
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/families/detail/FamilyPriorityDetailFragment.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/families/detail/FamilyPriorityDetailFragment.java
@@ -82,7 +82,7 @@ public class FamilyPriorityDetailFragment extends Fragment {
     }
 
     public void subscribeToViewModel() {
-        mFamilyInformationViewModel.getSelectedPriority().observe(this, this::bindPriority);
+        mFamilyInformationViewModel.SelectedPriority().observe(this, this::bindPriority);
     }
 
     public void bindPriority(@Nullable LifeMapPriority priority) {
@@ -132,5 +132,17 @@ public class FamilyPriorityDetailFragment extends Fragment {
         }
 
         super.onDetach();
+    }
+
+
+    @Override
+    public void onDestroyView() {
+        mProblemView = null;
+        mSolutionView = null;
+        mDueDateView = null;
+        mPriorityIndicatorCard = null;
+        mTitle = null;
+
+        super.onDestroyView();
     }
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/families/detail/FamilySidePrioritiesListFrag.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/families/detail/FamilySidePrioritiesListFrag.java
@@ -85,27 +85,24 @@ public class FamilySidePrioritiesListFrag extends Fragment implements Priorities
     @Override
     public void onDetach() {
         super.onDetach();
-        mFamilyViewModel.removeSelectedPriority();
     }
 
     private void subscribeToViewModel(){
-        mFamilyViewModel.getSelectedSnapshot().observe(this, this::updateSnapshot);
+        mFamilyViewModel.SelectedSnapshot().observe(this, this::updateSnapshot);
+        mFamilyViewModel.SelectedPriority().observe(this, mAdapter::setSelected);
     }
 
     private void updateSnapshot(Snapshot snapshot){
-        mFamilyViewModel.removeSelectedPriority();
-        mAdapter.setSnapshot(snapshot);
-        String title = getContext().getText(R.string.priorities_listcounttitle) +
-                " (" + snapshot.getPriorities().size() + ")";
-        mPrioritiesCount.setText(title);
+        if(snapshot!=null) {
+            mAdapter.setSnapshot(snapshot);
+            String title = getContext().getText(R.string.priorities_listcounttitle) +
+                    " (" + snapshot.getPriorities().size() + ")";
+            mPrioritiesCount.setText(title);
+        }
     }
 
     private void removeViewModelObservers() {
-        if (mFamilyViewModel.getSelectedSnapshot() != null &&
-                !mFamilyViewModel.getSelectedSnapshot().hasActiveObservers()) {
-
-                mFamilyViewModel.getSelectedSnapshot().removeObservers(this);
-        }
+        mFamilyViewModel.SelectedSnapshot().removeObservers(this);
     }
 
     @Override

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/survey/priorities/PriorityListFrag.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/survey/priorities/PriorityListFrag.java
@@ -1,4 +1,4 @@
-package org.fundacionparaguaya.advisorapp.ui.common;
+package org.fundacionparaguaya.advisorapp.ui.survey.priorities;
 
 import android.arch.lifecycle.ViewModelProviders;
 import android.os.Bundle;
@@ -16,6 +16,7 @@ import com.ontbee.legacyforks.cn.pedant.SweetAlert.SweetAlertDialog;
 import org.fundacionparaguaya.advisorapp.AdvisorApplication;
 import org.fundacionparaguaya.advisorapp.R;
 import org.fundacionparaguaya.advisorapp.injection.InjectionViewModelFactory;
+import org.fundacionparaguaya.advisorapp.ui.common.PrioritiesListAdapter;
 import org.fundacionparaguaya.advisorapp.ui.survey.SharedSurveyViewModel;
 
 import javax.inject.Inject;

--- a/app/src/main/res/layout/fragment_choosepriorities.xml
+++ b/app/src/main/res/layout/fragment_choosepriorities.xml
@@ -11,7 +11,7 @@
               android:layout_width="0dp"
               android:layout_height="match_parent" />
 
-    <fragment android:name="org.fundacionparaguaya.advisorapp.ui.common.PriorityListFrag"
+    <fragment android:name="org.fundacionparaguaya.advisorapp.ui.survey.priorities.PriorityListFrag"
               tools:layout="@layout/fragment_prioritylist"
               android:id="@+id/frag_choosepriorities_list"
               android:layout_weight="1"


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Description <!-- [OPTIONAL] -->
<!-- Include a short description of this pull request -->
Fixed a memory leak in the family detail page. On rotation/config change, all of the fragments were recreated and the activity wasn't being destroyed. In addition, the viewmodel would be recreated every time leading to a number of different bugs and general instability.

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- 

# Issues <!-- [IF APPLICABLE] -->
<!-- Fill in a bulleted list with issues that have been introduced or fixed -->
- Fixes
  - selected priority reset on rotation
  - high memory usage after rotation

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [X] Logged in to the application
  - [X] Fill out a snapshot for a new family
  - [ ] Fill out a snapshot for an existing family
  - [ ] Fill out priorities for a snapshot
  - [ ] View a family and it's priorities
- API Level:
  - [X] API Level 19
  - [ ] API Level 22
  - [ ] API Level 25
- Screen Size:
  - [] 7" screen size
  - [X] 8" screen size
  - [ ] 10" screen size
