### PR TITLE
Delay the sync job when authentication hasn't finished

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/model/LifeMapPriority.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/model/LifeMapPriority.java
@@ -20,12 +20,16 @@ public class LifeMapPriority {
     private String action;
     @ColumnInfo(name = "estimated_date")
     private Date estimatedDate;
+    @ColumnInfo(name = "is_achievement")
+    private boolean isAchievement;
 
-    public LifeMapPriority(Indicator indicator, String reason, String action, Date estimatedDate) {
+    public LifeMapPriority(Indicator indicator, String reason, String action, Date estimatedDate,
+                           boolean isAchievement) {
         this.indicator = indicator;
         this.reason = reason;
         this.action = action;
         this.estimatedDate = estimatedDate;
+        this.isAchievement = isAchievement;
     }
 
     public Indicator getIndicator() {
@@ -36,31 +40,36 @@ public class LifeMapPriority {
         return reason;
     }
 
+    public void setReason(String s) {
+        this.reason = s;
+    }
+
     public String getAction() {
         return action;
+    }
+
+    public void setAction(String s) {
+        this.action = s;
     }
 
     public Date getEstimatedDate() {
         return estimatedDate;
     }
 
+    public void setEstimatedDate(Date when) {
+        this.estimatedDate = when;
+    }
+
+    public boolean isAchievement() {
+        return isAchievement;
+    }
+
+    public void setAchievement(boolean achievement) {
+        isAchievement = achievement;
+    }
+
     public static Builder builder() {
         return new Builder();
-    }
-
-    public void setReason(String s)
-    {
-        this.reason = s;
-    }
-
-    public void setStrategy(String s)
-    {
-        this.action = s;
-    }
-
-    public void setWhen(Date when)
-    {
-        this.estimatedDate = when;
     }
 
     @Override
@@ -93,6 +102,7 @@ public class LifeMapPriority {
         private String reason;
         private String action;
         private Date estimatedDate;
+        private boolean isAchievement;
 
         public Builder indicator(Indicator indicator) {
             this.indicator = indicator;
@@ -114,8 +124,13 @@ public class LifeMapPriority {
             return this;
         }
 
+        public Builder isAchievement(boolean isAchievement) {
+            this.isAchievement = isAchievement;
+            return this;
+        }
+
         public LifeMapPriority build() {
-            return new LifeMapPriority(indicator, reason, action, estimatedDate);
+            return new LifeMapPriority(indicator, reason, action, estimatedDate, isAchievement);
         }
     }
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/IrMapper.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/IrMapper.java
@@ -276,7 +276,7 @@ public class IrMapper {
         ir.reason = defaultIfEmpty(priority.getReason(), "");
         ir.action = defaultIfEmpty(priority.getAction(), "");
         ir.estimatedDate = mapDate(priority.getEstimatedDate());
-        ir.isCompleted = false; // required field, not supported yet by application
+        ir.isAchievement = priority.isAchievement();
         return ir;
     }
 
@@ -370,6 +370,7 @@ public class IrMapper {
                 .reason(ir.reason)
                 .action(ir.action)
                 .estimatedDate(mapDate(ir.estimatedDate))
+                .isAchievement(ir.isAchievement)
                 .build();
     }
 
@@ -420,6 +421,8 @@ public class IrMapper {
     }
 
     private static Date mapDate(String ir) {
+        if (ir == null) return null;
+
         TimeZone tz = TimeZone.getTimeZone("UTC");
         DateFormat df = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
         df.setTimeZone(tz);

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/IrMapper.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/IrMapper.java
@@ -1,10 +1,13 @@
 package org.fundacionparaguaya.advisorapp.data.remote.intermediaterepresentation;
 
+import android.util.Log;
+
 import org.fundacionparaguaya.advisorapp.data.model.*;
 
 import java.text.*;
 import java.util.*;
 
+import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static org.fundacionparaguaya.advisorapp.data.model.BackgroundQuestion.QuestionType.ECONOMIC;
 import static org.fundacionparaguaya.advisorapp.data.model.BackgroundQuestion.QuestionType.PERSONAL;
@@ -15,6 +18,7 @@ import static org.fundacionparaguaya.advisorapp.data.model.IndicatorOption.Level
  */
 
 public class IrMapper {
+    public static String TAG = "IrMapper";
 
     //region Login
     public static Login mapLogin(LoginIr ir) {
@@ -107,6 +111,11 @@ public class IrMapper {
         List<BackgroundQuestion> questions = new ArrayList<>();
         for (String name : names) {
             SurveyQuestionIr questionIr = ir.schema.questions.get(name);
+            if (questionIr == null) {
+                Log.w(TAG, format("mapBackground: A non-existent question (%s) was referenced in "
+                        + "survey (id: %d) UI schema!", name, ir.id));
+                continue;
+            }
             questions.add(new BackgroundQuestion(
                     name,
                     questionIr.title.get("es"),

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/PriorityIr.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/PriorityIr.java
@@ -23,7 +23,7 @@ public class PriorityIr {
     @SerializedName("estimated_date")
     String estimatedDate;
     @SerializedName("is_attainment")
-    boolean isCompleted;
+    boolean isAchievement;
 
     @Override
     public boolean equals(Object o) {
@@ -39,7 +39,7 @@ public class PriorityIr {
                 .append(reason, that.reason)
                 .append(action, that.action)
                 .append(estimatedDate, that.estimatedDate)
-                .append(isCompleted, that.isCompleted)
+                .append(isAchievement, that.isAchievement)
                 .isEquals();
     }
 
@@ -52,7 +52,7 @@ public class PriorityIr {
                 .append(reason)
                 .append(action)
                 .append(estimatedDate)
-                .append(isCompleted)
+                .append(isAchievement)
                 .toHashCode();
     }
 }

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/jobs/JobCreator.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/jobs/JobCreator.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.evernote.android.job.Job;
 import org.fundacionparaguaya.advisorapp.AdvisorApplication;
+import org.fundacionparaguaya.advisorapp.data.remote.AuthenticationManager;
 import org.fundacionparaguaya.advisorapp.data.repositories.SyncManager;
 
 import javax.inject.Inject;
@@ -17,6 +18,8 @@ public class JobCreator implements com.evernote.android.job.JobCreator {
 
     @Inject
     SyncManager mSyncManager;
+    @Inject
+    AuthenticationManager mAuthManager;
 
     public JobCreator(AdvisorApplication application) {
         this.mApplication = application;
@@ -29,7 +32,7 @@ public class JobCreator implements com.evernote.android.job.JobCreator {
     public Job create(@NonNull String tag) {
         switch (tag) {
             case SyncJob.TAG:
-                return new SyncJob(mSyncManager);
+                return new SyncJob(mSyncManager, mAuthManager);
             case CleanJob.TAG:
                 return new CleanJob(mSyncManager);
             default:

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/jobs/SyncJob.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/jobs/SyncJob.java
@@ -6,7 +6,10 @@ import com.evernote.android.job.Job;
 import com.evernote.android.job.JobManager;
 import com.evernote.android.job.JobRequest;
 
+import org.fundacionparaguaya.advisorapp.data.remote.AuthenticationManager;
 import org.fundacionparaguaya.advisorapp.data.repositories.SyncManager;
+
+import static org.fundacionparaguaya.advisorapp.data.remote.AuthenticationManager.AuthenticationStatus.AUTHENTICATED;
 
 /**
  * A job to sync the database.
@@ -16,15 +19,20 @@ public class SyncJob extends Job {
     public static final String TAG = "SyncJob";
 
     private SyncManager mSyncManager;
+    private AuthenticationManager mAuthManager;
 
-    public SyncJob(SyncManager syncManager) {
+    public SyncJob(SyncManager syncManager, AuthenticationManager authManager) {
         super();
         this.mSyncManager = syncManager;
+        this.mAuthManager = authManager;
     }
 
     @Override
     @NonNull
     protected Result onRunJob(@NonNull Params params) {
+        if (mAuthManager.getStatus() != AUTHENTICATED)
+            return Result.RESCHEDULE;
+
         if (mSyncManager.sync())
             return Result.SUCCESS;
         else

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/survey/SharedSurveyViewModel.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/survey/SharedSurveyViewModel.java
@@ -240,8 +240,8 @@ public class SharedSurveyViewModel extends ViewModel {
             if(p.getIndicator().equals(newPriority.getIndicator()))
             {
                 p.setReason(newPriority.getReason());
-                p.setStrategy(newPriority.getAction());
-                p.setWhen(newPriority.getEstimatedDate());
+                p.setAction(newPriority.getAction());
+                p.setEstimatedDate(newPriority.getEstimatedDate());
             }
         }
 

--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/survey/priorities/EditPriorityActivity.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/ui/survey/priorities/EditPriorityActivity.java
@@ -15,16 +15,22 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.TextView;
+
 import org.fundacionparaguaya.advisorapp.AdvisorApplication;
 import org.fundacionparaguaya.advisorapp.R;
-import org.fundacionparaguaya.advisorapp.data.model.*;
+import org.fundacionparaguaya.advisorapp.data.model.Indicator;
+import org.fundacionparaguaya.advisorapp.data.model.IndicatorOption;
+import org.fundacionparaguaya.advisorapp.data.model.IndicatorQuestion;
+import org.fundacionparaguaya.advisorapp.data.model.LifeMapPriority;
+import org.fundacionparaguaya.advisorapp.data.model.Survey;
+import org.fundacionparaguaya.advisorapp.injection.InjectionViewModelFactory;
+import org.fundacionparaguaya.advisorapp.ui.common.widget.NumberStepperView;
 import org.fundacionparaguaya.advisorapp.util.IndicatorUtilities;
 import org.fundacionparaguaya.advisorapp.util.KeyboardUtils;
-import org.fundacionparaguaya.advisorapp.ui.common.widget.NumberStepperView;
-import org.fundacionparaguaya.advisorapp.injection.InjectionViewModelFactory;
+
+import java.util.Date;
 
 import javax.inject.Inject;
-import java.util.Date;
 
 /**
  * Pop up window that allows the user to input some details about the priority..
@@ -252,21 +258,13 @@ public class EditPriorityActivity extends FragmentActivity implements View.OnCli
 
     public static LifeMapPriority processResult(Intent result, Survey s)
     {
-        return processResult(result,
-                new LifeMapPriority
-                        (getIndicatorFromResult(result, s),
-                        "",
-                        "",
-                        null));
-    }
-
-    public static LifeMapPriority processResult(Intent result, LifeMapPriority p)
-    {
-        p.setReason(result.getStringExtra(RESPONSE_REASON_ARG));
-        p.setStrategy(result.getStringExtra(RESPONSE_ACTION_ARG));
-        p.setWhen((Date)result.getSerializableExtra(RESPONSE_DATE_ARG));
-
-        return p;
+        return LifeMapPriority.builder()
+                .indicator(getIndicatorFromResult(result, s))
+                .reason(result.getStringExtra(RESPONSE_REASON_ARG))
+                .action(result.getStringExtra(RESPONSE_ACTION_ARG))
+                .estimatedDate((Date)result.getSerializableExtra(RESPONSE_DATE_ARG))
+                .isAchievement(false) // default to a priority that is not a "proud of"
+                .build();
     }
     //endregion
 }

--- a/app/src/test/java/org/fundacionparaguaya/advisorapp/data/model/ModelUtils.java
+++ b/app/src/test/java/org/fundacionparaguaya/advisorapp/data/model/ModelUtils.java
@@ -98,7 +98,8 @@ public class ModelUtils {
         priorities.add(new LifeMapPriority(yellowIncomeOption.getIndicator(),
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                date("2018-02-13")));
+                date("2018-02-13"),
+                false));
 
         return new Snapshot(1, 1L, family.getId(), survey.getId(), false,
                 personalResponses, economicResponses, indicatorResponses, priorities,


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Addresses a race condition where a pending sync job was being scheduled before the app got authenticated
  - Reschedules the sync job if the app hasn't been authenticated yet

# Issues <!-- [IF APPLICABLE] -->
<!-- Fill in a bulleted list with issues that have been introduced or fixed -->
- Fixes
  - Fixes #467 

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [X] Logged in to the application
  - [ ] Fill out a snapshot for a new family
  - [ ] Fill out a snapshot for an existing family
  - [ ] Fill out priorities for a snapshot
  - [ ] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [X] API Level 22
  - [ ] API Level 25
- Screen Size:
  - [ ] 7" screen size
  - [X] 8" screen size
  - [ ] 10" screen size
