### PR TITLE
Fix an incorrect ID field in snapshot priorities

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/SnapshotOverviewIr.java
+++ b/app/src/main/java/org/fundacionparaguaya/advisorapp/data/remote/intermediaterepresentation/SnapshotOverviewIr.java
@@ -9,7 +9,7 @@ import java.util.List;
  */
 
 public class SnapshotOverviewIr {
-    @SerializedName("snapshot_indicator_id")
+    @SerializedName("snapshot_economic_id")
     long snapshotId;
     @SerializedName("family_id")
     long familyId;


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Fixes an incorrect field name
  - Previously, the snapshot indicator and economic IDs had the same value
  - Due to a change in the server, this assumption is no longer valid
  - Changes to use the correct field name

# Issues <!-- [IF APPLICABLE] -->
<!-- Fill in a bulleted list with issues that have been introduced or fixed -->
- Fixes
  - Fixes #508 by properly associating priorities with snapshots

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [X] Logged in to the application
  - [ ] Fill out a snapshot for a new family
  - [ ] Fill out a snapshot for an existing family
  - [ ] Fill out priorities for a snapshot
  - [X] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [X] API Level 22
  - [ ] API Level 25
- Screen Size:
  - [ ] 7" screen size
  - [X] 8" screen size
  - [ ] 10" screen size
