### PR TITLE
Add the FP demo server to server options

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/remote/ServerManager.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/remote/ServerManager.java
@@ -30,8 +30,9 @@ public class ServerManager {
         mPreferences = sharedPreferences;
 
         mServers = new Server[] {
-            new Server("http","povertystoplightiqp.org", 8080, context.getString(R.string.login_serverdev)),
+            new Server("https","demo.backend.povertystoplight.org", 443, context.getString(R.string.login_serverdemo)),
             new Server("https","testing.backend.povertystoplight.org", 443, context.getString(R.string.login_servertest)),
+            new Server("http","povertystoplightiqp.org", 8080, context.getString(R.string.login_serverdev)),
         };
 
         mSelected = new MutableLiveData<>();

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -35,6 +35,7 @@
     <string name="login_passwordprompt">Clave</string>
     <string name="login_action_signin">Initiar la Sesión</string>
     <string name="login_incorrectcredentials">Usuario y/o clave incorrectos.</string>
+    <string name="login_serverdemo">FP: Servidor de Demostración</string>
     <string name="login_servertest">FP: Servidor de Prueba</string>
     <string name="login_serverdev">WPI: Servidor de Desarrollo</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="login_passwordprompt">Password</string>
     <string name="login_action_signin">Login</string>
     <string name="login_incorrectcredentials">Hmm, that username or password didn\'t work.</string>
+    <string name="login_serverdemo">FP: Demo Server</string>
     <string name="login_servertest">FP: Test Server</string>
     <string name="login_serverdev">WPI: Development Server</string>
 


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Adds the FP demo server to the server options
- Reorders the servers to default to the demo server

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [ ] Logged in to the application
  - [ ] Fill out a snapshot for a new family
  - [ ] Fill out a snapshot for an existing family
  - [ ] Fill out priorities for a snapshot
  - [ ] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [ ] API Level 22
  - [ ] API Level 25
- Screen Size:
  - [ ] 7" screen size
  - [ ] 8" screen size
  - [ ] 10" screen size
