### PR TITLE
Fix issue where saved server was forgotten

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/dashboard/DashActivity.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/dashboard/DashActivity.java
@@ -130,6 +130,7 @@ public class DashActivity extends AbstractFragSwitcherActivity implements Displa
 
         //update last sync label when the sync manager updates
         mSyncManager.getProgress().observe(this, (value) -> {
+
             if (value != null) {
                 if (value.getLastSyncedTime() == -1) {
                     mLastSyncTextView.setText(R.string.topbar_lastsync_never);
@@ -137,7 +138,7 @@ public class DashActivity extends AbstractFragSwitcherActivity implements Displa
                     mLastSyncTextView.setReferenceTime(value.getLastSyncedTime());
                 }
 
-                if (value.getSyncState() == SYNCING) {
+                if (SyncJob.isSyncInProgress() || value.getSyncState() == SYNCING) {
                     mSyncLabel.setText(R.string.topbar_synclabel_syncing);
                     mSyncArea.setEnabled(false);
                     mSyncButtonIcon.setImageResource(R.drawable.ic_dashtopbar_sync);

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/login/LoginFragment.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/login/LoginFragment.java
@@ -23,8 +23,9 @@ import android.widget.ArrayAdapter;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
+
 import com.mixpanel.android.mpmetrics.MixpanelAPI;
-import io.rmiri.buttonloading.ButtonLoading;
+
 import org.fundacionparaguaya.adviserplatform.AdviserApplication;
 import org.fundacionparaguaya.adviserplatform.BuildConfig;
 import org.fundacionparaguaya.adviserplatform.R;
@@ -38,6 +39,8 @@ import org.fundacionparaguaya.adviserplatform.util.MixpanelHelper;
 import org.joda.time.DateTime;
 
 import javax.inject.Inject;
+
+import io.rmiri.buttonloading.ButtonLoading;
 
 /**
  * The fragment for the login page.
@@ -128,9 +131,10 @@ public class LoginFragment extends Fragment implements TextWatcher {
             mViewModel.setSelectedServer(server);
         });
 
-        if(mViewModel.getServers().length>0) {
-            mServerSpinner.selectFirstItem();
-            mViewModel.setSelectedServer(mViewModel.getServers()[0]);
+        Server selectedServer = mViewModel.getSelectedServer().getValue();
+        if (selectedServer != null) {
+            int selectedServerIndex = spinAdapter.getPosition(selectedServer);
+            mServerSpinner.setSelectedPosition(selectedServerIndex);
         }
 
         mPasswordView.setOnEditorActionListener((textView, id, keyEvent) -> {


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Fixes an issue where the saved server was being changed to default by login page server spinner

# Issues <!-- [IF APPLICABLE] -->
<!-- Fill in a bulleted list with issues that have been introduced or fixed -->
- Fixes
  - Fixes #467 which was occurring because the saved server was being changed before login

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [X] Logged in to the application
  - [ ] Fill out a snapshot for a new family
  - [ ] Fill out a snapshot for an existing family
  - [ ] Fill out priorities for a snapshot
  - [ ] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [X] API Level 22
  - [ ] API Level 25
- Screen Size:
  - [ ] 7" screen size
  - [X] 8" screen size
  - [ ] 10" screen size
