### PR TITLE
Fixed laggy animation inbetween stacked fragments

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/base/AbstractStackedFrag.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/base/AbstractStackedFrag.java
@@ -1,7 +1,9 @@
 package org.fundacionparaguaya.adviserplatform.ui.base;
 
 import android.content.Context;
+import android.os.Build;
 import android.support.v4.app.Fragment;
+import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import org.fundacionparaguaya.adviserplatform.R;
@@ -17,7 +19,6 @@ public abstract class AbstractStackedFrag extends Fragment
 
     boolean mDidEnter = false;
     int lastEnterAnimId = -1;
-    int lastBackStackCount =-1;
 
     /**
      * Gets parent fragment (of type AbstractTabbedFrag) and then calls navigation function. Current
@@ -52,8 +53,42 @@ public abstract class AbstractStackedFrag extends Fragment
             lastEnterAnimId = nextAnim;
         }
 
-        return shouldNotAnimate ? AnimationUtils.loadAnimation(getActivity(), R.anim.none)
-                : super.onCreateAnimation(transit, enter, nextAnim);
+        if(shouldNotAnimate) return AnimationUtils.loadAnimation(getActivity(), R.anim.none);
+        else
+        {
+            Animation animation = super.onCreateAnimation(transit, enter, nextAnim);
+
+            // HW layer support only exists on API 11+
+            if ( Build.VERSION.SDK_INT == 11) {
+                if (animation == null && nextAnim != 0) {
+                    animation = AnimationUtils.loadAnimation(getActivity(), nextAnim);
+                }
+
+                View view = getView();
+
+                if (animation != null && view!=null) {
+                    view.setLayerType(View.LAYER_TYPE_HARDWARE, null);
+
+                    animation.setAnimationListener(new Animation.AnimationListener() {
+                        @Override
+                        public void onAnimationStart(Animation animation) {
+
+                        }
+
+                        public void onAnimationEnd(Animation animation) {
+                            view.setLayerType(View.LAYER_TYPE_NONE, null);
+                        }
+
+                        @Override
+                        public void onAnimationRepeat(Animation animation) {
+
+                        }
+                    });
+                }
+            }
+
+            return animation;
+        }
     }
 
     @Override

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/families/detail/FamilyLifeMapFragment.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/ui/families/detail/FamilyLifeMapFragment.java
@@ -98,7 +98,7 @@ public class FamilyLifeMapFragment extends Fragment implements LifeMapFragmentCa
     {
         mFamilyDetailViewModel.Snapshots().observe(this, (snapshots) -> {
             //This is necessary to completely clear the Array Adapter every time snapshots get updated
-            mSpinnerAdapter = new ArrayAdapter<>(this.getContext(), R.layout.item_tv_spinner);
+            mSpinnerAdapter = new ArrayAdapter<>(getContext(), R.layout.item_tv_spinner);
             mSnapshotSpinner.setAdapter(mSpinnerAdapter);
 
             if(snapshots!=null) {


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Used a hardware layer for animations to improve animation performance 

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [X] Logged in to the application
  - [X] Fill out a snapshot for a new family
  - [ ] Fill out a snapshot for an existing family
  - [ ] Fill out priorities for a snapshot
  - [ ] View a family and it's priorities
- API Level:
  - [X] API Level 19
  - [ ] API Level 22
  - [X] API Level 25
- Screen Size:
  - [X] 7" screen size
  - [X] 8" screen size
  - [ ] 10" screen size
