### PR TITLE
Enable CI notifications for release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ experimental:
     branches:
       only:
         - master
+        - release/*
 
 jobs:
   build-and-test:


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Enables build failure notifications via Slack on `release/*` branches
  - NOTE: this is an experimental feature; I'm not sure if the `/*` regex will work

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
Not applicable