### PR TITLE
Allocate more memory for release gradle build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
       - run:
           name: Build Release APK
-          command: ./gradlew assembleRelease
+          command: ./gradlew assembleRelease -Dorg.gradle.jvmargs=-Xmx2048M
       - store_artifacts:
           name: Store Release APK
           path: app/build/outputs/apk/release/


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Adds an argument to the deploy task which gives gradle more memory
  - Fixes an issue where the last deploy failed due to a lack of memory for dex support
  - Upgraded from 1Gb to 2Gb; the minimum required is 1.5Gb

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
Tested this in the same CircleCI container that runs our release process and it worked.
