### PR TITLE
Fix order issue with survey questions

### DIFF
--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/BackgroundQuestion.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/BackgroundQuestion.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,6 +45,11 @@ public class BackgroundQuestion extends SurveyQuestion {
 
     public Map<String, String> getOptions() {
         return options;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 
     @Override

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/Family.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/Family.java
@@ -10,6 +10,7 @@ import android.support.annotation.NonNull;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.fundacionparaguaya.adviserplatform.data.local.Converters;
 
 import java.util.Date;
@@ -134,6 +135,11 @@ public class Family {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 
     @Override

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/FamilyMember.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/FamilyMember.java
@@ -4,6 +4,7 @@ import android.arch.persistence.room.ColumnInfo;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Map;
 
@@ -92,6 +93,11 @@ public class FamilyMember {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 
     @Override

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/Indicator.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/Indicator.java
@@ -2,7 +2,7 @@ package org.fundacionparaguaya.adviserplatform.data.model;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import timber.log.Timber;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
@@ -10,6 +10,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import timber.log.Timber;
 
 import static java.lang.String.format;
 
@@ -58,6 +60,11 @@ public class Indicator {
         for (IndicatorOption option : options) { // add references to this indicator
             option.setIndicator(this);
         }
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 
     @Override

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/IndicatorOption.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/IndicatorOption.java
@@ -6,6 +6,7 @@ import com.google.gson.annotations.SerializedName;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  *  An indicator option is a definition for one of the three levels an indicator can have. It's level is determined
@@ -47,6 +48,11 @@ public class IndicatorOption implements Comparable<IndicatorOption> {
 
     public void setIndicator(Indicator indicator) {
         this.indicator = indicator;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 
     @Override

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/IndicatorQuestion.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/IndicatorQuestion.java
@@ -7,6 +7,7 @@ import com.google.gson.annotations.SerializedName;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.List;
 
@@ -33,6 +34,11 @@ public class IndicatorQuestion extends SurveyQuestion implements Comparable {
 
     public List<IndicatorOption> getOptions() {
         return options;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 
     @Override

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/LifeMapPriority.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/LifeMapPriority.java
@@ -4,6 +4,7 @@ import android.arch.persistence.room.ColumnInfo;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Date;
 
@@ -70,6 +71,11 @@ public class LifeMapPriority {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 
     @Override

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/Login.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/Login.java
@@ -2,6 +2,7 @@ package org.fundacionparaguaya.adviserplatform.data.model;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * The login of a user.
@@ -42,6 +43,11 @@ public class Login {
 
     public String getRefreshToken() {
         return refreshToken;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 
     @Override

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/Survey.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/Survey.java
@@ -8,6 +8,8 @@ import android.arch.persistence.room.TypeConverters;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.MultilineRecursiveToStringStyle;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.fundacionparaguaya.adviserplatform.data.local.Converters;
 
 import java.util.List;
@@ -90,6 +92,11 @@ public class Survey {
 
     public List<IndicatorQuestion> getIndicatorQuestions() {
         return indicatorQuestions;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this, new MultilineRecursiveToStringStyle());
     }
 
     @Override

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/SurveyQuestion.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/SurveyQuestion.java
@@ -4,6 +4,7 @@ import android.arch.persistence.room.ColumnInfo;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * A question which can be presented to a family and responded to from a survey.
@@ -40,6 +41,11 @@ public class SurveyQuestion {
 
     public ResponseType getResponseType(){
         return type;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 
     @Override

--- a/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/User.java
+++ b/app/src/main/java/org/fundacionparaguaya/adviserplatform/data/model/User.java
@@ -2,6 +2,7 @@ package org.fundacionparaguaya.adviserplatform.data.model;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * A user which can use the application.
@@ -59,6 +60,11 @@ public class User {
         public User build() {
             return new User(username, password, login);
         }
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 
     @Override

--- a/app/src/test/java/org/fundacionparaguaya/adviserplatform/data/model/ModelUtils.java
+++ b/app/src/test/java/org/fundacionparaguaya/adviserplatform/data/model/ModelUtils.java
@@ -70,6 +70,11 @@ public class ModelUtils {
         economicQuestions.add(new BackgroundQuestion("activityMain",
                 "Ingrese su actividad principal.", false, STRING, ECONOMIC,
                 activityMainOptions));
+        activityMainOptions.put("Agricultura, Silvicultura y Pesca", "AGRICULTURE");
+        activityMainOptions.put("Minas y Canteras", "MINING-QUARRYING");
+        economicQuestions.add(new BackgroundQuestion("activitySecondary",
+                "Ingrese su actividad otro.", false, STRING, ECONOMIC,
+                activityMainOptions));
         List<IndicatorQuestion> indicatorQuestions = new ArrayList<>();
         List<IndicatorOption> incomeOptions = new ArrayList<>();
         incomeOptions.add(indicatorOption("1-3.jpg", "la línea de la pobreza", Green));

--- a/app/src/test/java/org/fundacionparaguaya/adviserplatform/data/remote/intermediaterepresentation/IrUtils.java
+++ b/app/src/test/java/org/fundacionparaguaya/adviserplatform/data/remote/intermediaterepresentation/IrUtils.java
@@ -79,6 +79,7 @@ public class IrUtils {
         ir.questions.put("firstName", firstNameQuestionIr());
         ir.questions.put("income", incomeQuestionIr());
         ir.questions.put("activityMain", activityMainQuestionIr());
+        ir.questions.put("activitySecondary", activitySecondaryQuestionIr());
         return ir;
     }
 
@@ -121,15 +122,23 @@ public class IrUtils {
         return ir;
     }
 
+    public static SurveyQuestionIr activitySecondaryQuestionIr() {
+        SurveyQuestionIr questionIr = activityMainQuestionIr();
+        questionIr.title.put("es", "Ingrese su actividad otro.");
+        return questionIr;
+    }
+
     public static SurveyUiSchemaIr surveyUiSchemaIr() {
         SurveyUiSchemaIr ir = new SurveyUiSchemaIr();
         ir.order = new ArrayList<>();
         ir.order.add("firstName");
         ir.order.add("activityMain");
+        ir.order.add("activitySecondary");
         ir.order.add("income");
         ir.personalQuestions = new ArrayList<>();
         ir.personalQuestions.add("firstName");
         ir.economicQuestions = new ArrayList<>();
+        ir.economicQuestions.add("activitySecondary");
         ir.economicQuestions.add("activityMain");
         ir.indicatorQuestions = new ArrayList<>();
         ir.indicatorQuestions.add("income");


### PR DESCRIPTION
<!-- Fill in the following sections, deleting any sections that you leave blank -->

# Changes <!-- [REQIURED] -->
<!-- Fill in a bulleted list with changes made in this pull request -->
- Changes the `IrMapper` to use the `ui:order` instead of the `ui:...Questions` lists
  - This was made because the assumption that the individual `ui:...Questions` lists were in order is not true
  - Updated test cases to test for this problem
- Adds `toString` methods to most of the model classes for easier test failure debugging

# Issues <!-- [IF APPLICABLE] -->
<!-- Fill in a bulleted list with issues that have been introduced or fixed -->
- Fixes
  - Fixes #537 by using the correct order from the server

# Tests <!-- [REQUIRED] -->
<!-- Check off the following tests (using [X]) that you performed to ensure that your changes work -->
This code has been tested in the following ways:
- Tasks:
  - [X] Logged in to the application
  - [ ] Fill out a snapshot for a new family
  - [ ] Fill out a snapshot for an existing family
  - [ ] Fill out priorities for a snapshot
  - [X] View a family and it's priorities
- API Level:
  - [ ] API Level 19
  - [X] API Level 22
  - [ ] API Level 25
- Screen Size:
  - [ ] 7" screen size
  - [X] 8" screen size
  - [ ] 10" screen size
